### PR TITLE
Add CPP standard lib backend, revise OpenACC and OMP_TARGET

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,15 @@ else()
   message(STATUS "DISABLING OpenCL Implementation")
 endif()
 
+if (ENABLE_CPP_STD)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -lpthread -D_ENABLE_CPP_STD_")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lpthread -D_ENABLE_CPP_STD_")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+  message(STATUS "ENABLING C++ Standard Atomics Implementation")
+else()
+  message(STATUS "DISABLING C++ Standard Atomics Implementation")
+endif()
+
 #------------------------------------------------------------------------
 # Add package paths
 #------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -226,33 +226,31 @@ for( i=0; i<iters; i++ ){
 ### OMP with Target Offloading
 * CMake Build Flags: -DENABLE_OMP_TARGET=ON -DOFFLOAD_TARGETS=target_options
 where "target_options" is passed to the GNU -foffload compiler flag
-* Implementation Language: C++ & C using GNU intrinsics
+* Implementation Language: C++ & C
 * Users may define $OMP_DEFAULT_DEVICE to select a different target device ID,
 otherwise the system default is utilized
 * Maps provided PEs argument to team-level parallelism, iterations for a given team
 are automatically subdivided across threads within each team
 * Utilizes unsigned 64-bit integers for the ARRAY and IDX values
-* Utilizes \_\_ATOMIC\_RELAXED where appropriate
-* Intrinsic documentation: [GNU Atomics](https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html)
 
 | Benchmark | Supported? |
 | ------ | ------ |
 | RAND_ADD | yes |
-| RAND_CAS | yes |
+| RAND_CAS | no |
 | STRIDE1_ADD | yes |
-| STRIDE1_CAS | yes |
+| STRIDE1_CAS | no |
 | STRIDEN_ADD | yes |
-| STRIDEN_CAS | yes |
+| STRIDEN_CAS | no |
 | PTRCHASE_ADD | yes |
-| PTRCHASE_CAS | yes |
+| PTRCHASE_CAS | no |
 | CENTRAL_ADD | yes |
-| CENTRAL_CAS | yes |
+| CENTRAL_CAS | no |
 | SG_ADD | yes |
-| SG_CAS | yes |
+| SG_CAS | no |
 | SCATTER_ADD | yes |
-| SCATTER_CAS | yes |
+| SCATTER_CAS | no |
 | GATHER_ADD | yes |
-| GATHER_CAS | yes |
+| GATHER_CAS | no |
 
 ### OpenSHMEM
 * CMake Build Flag: -DENABLE_OPENSHMEM=ON
@@ -359,32 +357,30 @@ fetch the index for a given iteration (ex, RAND_ADD, RAND_CAS)
 ### OpenACC
 * CMake Build Flags: -DENABLE_OPENACC=ON -DOFFLOAD_TARGETS=target_options
 where "target_options" is passed to the GNU -foffload compiler flag
-* Implementation Language: C++ & C using GNU intrinsics
+* Implementation Language: C++ & C
 * Users must define both $ACC_DEVICE_TYPE and $ACC_DEVICE_ID to set
 the target device type and ID, respectively
 * Maps provided PEs argument to gang-level parallelism
 * Utilizes unsigned 64-bit integers for the ARRAY and IDX values
-* Utilizes \_\_ATOMIC\_RELAXED where appropriate
-* Intrinsic documentation: [GNU Atomics](https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html)
 
 | Benchmark | Supported? |
 | ------ | ------ |
 | RAND_ADD | yes |
-| RAND_CAS | yes |
+| RAND_CAS | no |
 | STRIDE1_ADD | yes |
-| STRIDE1_CAS | yes |
+| STRIDE1_CAS | no |
 | STRIDEN_ADD | yes |
-| STRIDEN_CAS | yes |
+| STRIDEN_CAS | no |
 | PTRCHASE_ADD | yes |
-| PTRCHASE_CAS | yes |
+| PTRCHASE_CAS | no |
 | CENTRAL_ADD | yes |
-| CENTRAL_CAS | yes |
+| CENTRAL_CAS | no |
 | SG_ADD | yes |
-| SG_CAS | yes |
+| SG_CAS | no |
 | SCATTER_ADD | yes |
-| SCATTER_CAS | yes |
+| SCATTER_CAS | no |
 | GATHER_ADD | yes |
-| GATHER_CAS | yes |
+| GATHER_CAS | no |
 
 ### Pthreads
 * CMake Build Flags: -DENABLE_PTHREADS=ON
@@ -443,6 +439,7 @@ the OpenCL target platform and device, respectively
 * CMake Build Flags: -DENABLE_CPP_STD=ON
 * Implementation Language: C++11
 * Utilizes unsigned 64-bit integers for the ARRAY and IDX values
+* Utilizes C++11 standard library threads and atomic operations
 
 | Benchmark | Supported? |
 | ------ | ------ |

--- a/README.md
+++ b/README.md
@@ -439,6 +439,30 @@ the OpenCL target platform and device, respectively
 | GATHER_ADD | yes |
 | GATHER_CAS | yes |
 
+### C++ Standard Threads & Atomics
+* CMake Build Flags: -DENABLE_CPP_STD=ON
+* Implementation Language: C++11
+* Utilizes unsigned 64-bit integers for the ARRAY and IDX values
+
+| Benchmark | Supported? |
+| ------ | ------ |
+| RAND_ADD | yes |
+| RAND_CAS | yes |
+| STRIDE1_ADD | yes |
+| STRIDE1_CAS | yes |
+| STRIDEN_ADD | yes |
+| STRIDEN_CAS | yes |
+| PTRCHASE_ADD | yes |
+| PTRCHASE_CAS | yes |
+| CENTRAL_ADD | yes |
+| CENTRAL_CAS | yes |
+| SG_ADD | yes |
+| SG_CAS | yes |
+| SCATTER_ADD | yes |
+| SCATTER_CAS | yes |
+| GATHER_ADD | yes |
+| GATHER_CAS | yes |
+
 ## Execution Parameters
 
 ### Parameters

--- a/src/CircusTent/CMakeLists.txt
+++ b/src/CircusTent/CMakeLists.txt
@@ -49,4 +49,8 @@ if (ENABLE_OPENCL)
   target_link_libraries(circustent OpenCL)
 endif()
 
+if (ENABLE_CPP_STD)
+  add_executable(circustent ${CTSrcs} $<TARGET_OBJECTS:CT_CPP_STD_OBJS>)
+endif()
+
 install(TARGETS circustent DESTINATION bin)

--- a/src/CircusTent/CT_Main.cpp
+++ b/src/CircusTent/CT_Main.cpp
@@ -42,7 +42,58 @@
 #include "Impl/CT_OPENCL/CT_OPENCL.h"
 #endif
 
+#ifdef _ENABLE_CPP_STD_
+#include "Impl/CT_CPP_STD/CT_CPP_STD.h"
+#endif
+
 void PrintTiming( double Timing, double GAMS );
+
+#ifdef _ENABLE_CPP_STD_
+void RunBenchCppStd(CTOpts *Opts) {
+  // Init the object
+  CT_CPP_STD *CT = new CT_CPP_STD(Opts->GetBenchType(),
+                          	     Opts->GetAtomType());
+
+  if ( !CT ) {
+    std::cout << "ERROR: COULD NOT ALLOCATE CT_CPP_STD OBJECTS" << std::endl;
+    return ;
+  }
+
+  // Allocate the data
+  if (!CT->AllocateData( Opts->GetMemSize(),
+                         Opts->GetPEs(),
+                         Opts->GetIters(),
+                         Opts->GetStride())){
+      std::cout << "ERROR: COULD NOT ALLOCATE MEMORY FOR CT_CPP_STD" << std::endl;
+      CT->FreeData();
+      delete CT;
+      return;
+  }
+
+  // Execute the benchmark
+  double Timing = 0;
+  double GAMS = 0.;
+  if ( !CT->Execute(Timing, GAMS) ) {
+    std::cout << "ERROR : COULD NOT EXECUTE BENCHMARK FOR CT_CPP_STD" << std::endl;
+    CT->FreeData();
+    free ( CT );
+    return;
+  }
+
+  // Free the data
+  if ( !CT->FreeData() ) {
+    std::cout << "ERROR: COULD NOT FREE THE MEMORY FOR CT_OCL" << std::endl;
+    delete CT;
+    return;
+  }
+
+  // Print the timing
+  PrintTiming( Timing, GAMS );
+
+  // Free the structure
+  delete CT;
+}
+#endif
 
 #ifdef _ENABLE_OPENCL_
 void RunBenchOpenCL(CTOpts *Opts) {
@@ -476,6 +527,9 @@ int main( int argc, char **argv ){
 #endif
 #ifdef _ENABLE_OPENCL_
     RunBenchOpenCL(Opts);
+#endif
+#ifdef _ENABLE_CPP_STD_
+    RunBenchCppStd(Opts);
 #endif
   }
 

--- a/src/CircusTent/CT_Main.cpp
+++ b/src/CircusTent/CT_Main.cpp
@@ -152,9 +152,16 @@ void RunBenchOpenCL(CTOpts *Opts) {
 
 #ifdef _ENABLE_OPENACC_
 void RunBenchOpenACC( CTOpts *Opts ){
+
+  if(Opts->GetAtomType() == CTBaseImpl::CTAtomType::CT_CAS){
+    std::cout << "ERROR : CAS IMPLEMENTATION NOT SUPPORTED IN CT_OPENACC" << std::endl;
+    return;
+  }
+
   // init the OpenACC object
   CT_OPENACC *CT = new CT_OPENACC(Opts->GetBenchType(),
                                   Opts->GetAtomType());
+
   if( !CT ){
     std::cout << "ERROR : COULD NOT ALLOCATE CT_OPENACC OBJECTS" << std::endl;
     return;
@@ -391,6 +398,12 @@ void RunBenchOpenSHMEM( CTOpts *Opts ){
 
 #ifdef _ENABLE_OMP_TARGET_
 void RunBenchOMPTarget( CTOpts *Opts ){
+
+  if(Opts->GetAtomType() == CTBaseImpl::CTAtomType::CT_CAS){
+    std::cout << "ERROR : CAS IMPLEMENTATION NOT SUPPORTED IN CT_OMP_TARGET" << std::endl;
+    return;
+  }
+
   // init the OpenMP Target object
   CT_OMP_TARGET *CT = new CT_OMP_TARGET(Opts->GetBenchType(),
                                         Opts->GetAtomType());

--- a/src/CircusTent/Impl/CMakeLists.txt
+++ b/src/CircusTent/Impl/CMakeLists.txt
@@ -37,4 +37,8 @@ if (ENABLE_OPENCL)
   add_subdirectory(CT_OPENCL)
 endif()
 
+if (ENABLE_CPP_STD)
+  add_subdirectory(CT_CPP_STD)
+endif()
+
 # EOF

--- a/src/CircusTent/Impl/CT_CPP_STD/CMakeLists.txt
+++ b/src/CircusTent/Impl/CT_CPP_STD/CMakeLists.txt
@@ -1,0 +1,21 @@
+# src/Impl/CT_CPP_STD CMakeLists.txt
+# Copyright (C) 2017-2021 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+
+set(CT_CPP_STD_SRCS
+)
+
+if (ENABLE_CPP_STD)
+  set(CT_CPP_STD_SRCS ${CT_CPP_STD_SRCS} CT_CPP_STD.h CT_CPP_STD.cpp CT_CPP_STD_IMPL.cpp)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
+include_directories(${CT_INCLUDE_PATH})
+include_directories(./)
+
+add_library(CT_CPP_STD_OBJS OBJECT ${CT_CPP_STD_SRCS})

--- a/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.cpp
+++ b/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.cpp
@@ -1,0 +1,336 @@
+//
+// _CT_CPP_STD_CPP_
+//
+// Copyright (C) 2017-2021 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CT_CPP_STD.h"
+
+#ifdef _CT_CPP_STD_H_
+
+CT_CPP_STD::CT_CPP_STD(CTBaseImpl::CTBenchType B,
+                       CTBaseImpl::CTAtomType A) :
+                         CTBaseImpl("CPP_STD",B,A),
+                         Array(nullptr),
+                         Idx(nullptr),
+                         memSize(0),
+                         pes(0),
+                         iters(0),
+                         elems(0),
+                         stride(0) {
+}
+
+CT_CPP_STD::~CT_CPP_STD(){
+}
+
+bool CT_CPP_STD::Execute(double &Timing, double &GAMS){
+
+  CTBaseImpl::CTBenchType BType   = this->GetBenchType(); // benchmark type
+  CTBaseImpl::CTAtomType AType    = this->GetAtomType();  // atomic type
+  uint64_t i        = 0;  // loop var
+  double StartTime  = 0.; // start time
+  double EndTime    = 0.; // end time
+  double OPS        = 0.; // billions of operations
+  std::atomic<std::uint64_t> barrier_ctr(0); // Counter for kernel start barrier
+  std::thread threads[pes];
+
+  // determine the benchmark type
+  if( BType == CT_RAND ){
+    switch( AType ){
+    case CT_ADD:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::RAND_ADD, this, i, &barrier_ctr, &StartTime);
+
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(1,iters,pes);
+      break;
+    case CT_CAS:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::RAND_CAS, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(1,iters,pes);
+      break;
+    default:
+      this->ReportBenchError();
+      return false;
+      break;
+    }
+  }else if( BType == CT_STRIDE1 ){
+    switch( AType ){
+    case CT_ADD:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::STRIDE1_ADD, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(1,iters,pes);
+      break;
+    case CT_CAS:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::STRIDE1_CAS, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(1,iters,pes);
+      break;
+    default:
+      this->ReportBenchError();
+      return false;
+      break;
+    }
+  }else if( BType == CT_STRIDEN ){
+    switch( AType ){
+    case CT_ADD:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::STRIDEN_ADD, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(1,iters,pes);
+      break;
+    case CT_CAS:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::STRIDEN_CAS, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(1,iters,pes);
+      break;
+    default:
+      this->ReportBenchError();
+      return false;
+      break;
+    }
+  }else if( BType == CT_PTRCHASE ){
+    switch( AType ){
+    case CT_ADD:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::PTRCHASE_ADD, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(1,iters,pes);
+      break;
+    case CT_CAS:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::PTRCHASE_CAS, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(1,iters,pes);
+      break;
+    default:
+      this->ReportBenchError();
+      return false;
+      break;
+    }
+  }else if( BType == CT_SG ){
+    switch( AType ){
+    case CT_ADD:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::SG_ADD, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(4,iters,pes);
+      break;
+    case CT_CAS:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::SG_CAS, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(4,iters,pes);
+      break;
+    default:
+      this->ReportBenchError();
+      return false;
+      break;
+    }
+  }else if( BType == CT_CENTRAL ){
+    switch( AType ){
+    case CT_ADD:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::CENTRAL_ADD, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(1,iters,pes);
+      break;
+    case CT_CAS:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::CENTRAL_CAS, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(1,iters,pes);
+      break;
+    default:
+      this->ReportBenchError();
+      return false;
+      break;
+    }
+  }else if( BType == CT_SCATTER ){
+    switch( AType ){
+    case CT_ADD:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::SCATTER_ADD, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(3,iters,pes);
+      break;
+    case CT_CAS:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::SCATTER_CAS, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(3,iters,pes);
+      break;
+    default:
+      this->ReportBenchError();
+      return false;
+      break;
+    }
+  }else if( BType == CT_GATHER ){
+    switch( AType ){
+    case CT_ADD:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::GATHER_ADD, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(3,iters,pes);
+      break;
+    case CT_CAS:
+      for(i = 0; i < pes; i++){
+        threads[i] = std::thread(&CT_CPP_STD::GATHER_CAS, this, i, &barrier_ctr, &StartTime);
+      }
+      JoinThreads(threads);
+      EndTime   = this->MySecond();
+      OPS = this->GAM(3,iters,pes);
+      break;
+    default:
+      this->ReportBenchError();
+      return false;
+      break;
+    }
+  }else{
+    this->ReportBenchError();
+    return false;
+  }
+
+  barrier_ctr = 0;
+  Timing = this->Runtime(StartTime,EndTime);
+  GAMS   = OPS/Timing;
+
+  return true;
+}
+
+bool CT_CPP_STD::AllocateData(uint64_t m,
+                              uint64_t p,
+                              uint64_t i,
+                              uint64_t s){
+  // save the data
+  memSize = m;
+  pes = p;
+  iters = i;
+  stride = s;
+
+  // allocate all the memory
+  if( pes == 0 ){
+    std::cout << "CT_CPP_STD::AllocateData : 'pes' cannot be 0" << std::endl;
+    return false;
+  }
+  if( iters == 0 ){
+    std::cout << "CT_CPP_STD::AllocateData : 'iters' cannot be 0" << std::endl;
+    return false;
+  }
+  if( stride == 0 ){
+    std::cout << "CT_CPP_STD::AllocateData : 'stride' cannot be 0" << std::endl;
+    return false;
+  }
+
+  // calculate the number of elements
+  elems = (memSize/8);
+
+  // test to see whether we'll stride out of bounds
+  uint64_t end = (pes * iters * stride)-stride;
+  if( end > elems ){
+    std::cout << "CT_CPP_STD::AllocateData : 'Array' is not large enough for pes="
+              << pes << "; iters=" << iters << ";stride =" << stride
+              << std::endl;
+    return false;
+  }
+
+  Array =  new (std::nothrow) std::atomic<std::uint64_t>[elems];
+  if( Array == nullptr ){
+    std::cout << "CT_CPP_STD::AllocateData : 'Array' could not be allocated" << std::endl;
+    return false;
+  }
+
+  Idx =  new (std::nothrow) std::atomic<std::uint64_t>[(pes+1)*iters];
+  if( Idx == nullptr ){
+    std::cout << "CT_CPP_STD::AllocateData : 'Idx' could not be allocated" << std::endl;
+    delete[] Array;
+    return false;
+  }
+
+  // initiate the random array
+  srand(time(NULL));
+  if( this->GetBenchType() == CT_PTRCHASE ){
+    for( unsigned i=0; i<((pes+1)*iters); i++ ){
+      Idx[i] = (uint64_t)(rand()%((pes+1)*iters));
+    }
+  }else{
+    for( unsigned i=0; i<((pes+1)*iters); i++ ){
+      Idx[i] = (uint64_t)(rand()%(elems-1));
+    }
+  }
+  for( unsigned i=0; i<elems; i++ ){
+    Array[i] = (uint64_t)(rand());
+  }
+
+  std::cout << "RUNNING WITH NUM_THREADS = " << pes << std::endl;
+
+  return true;
+}
+
+bool CT_CPP_STD::FreeData(){
+  if( Array ){
+    delete[] Array;
+  }
+  if( Idx ){
+    delete[] Idx;
+  }
+  return true;
+}
+
+void CT_CPP_STD::JoinThreads(std::thread *threads){
+  uint64_t i;
+  for(i = 0; i < pes; i++){
+    threads[i].join();
+  }
+}
+
+void CT_CPP_STD::MyBarrier(std::atomic<std::uint64_t> *barrier_ctr){
+
+  // Increment barrier_ctr
+  barrier_ctr->fetch_add(1, std::memory_order_relaxed);
+
+  // Spin until barrier_ctr == pes
+  while(barrier_ctr->load(std::memory_order_relaxed) != pes){};
+}
+
+#endif
+
+// EOF

--- a/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.h
+++ b/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.h
@@ -31,13 +31,13 @@
 
 class CT_CPP_STD : public CTBaseImpl{
 private:
-  std::atomic<std::uint64_t> *Array;          ///< CT_CPP_STD: Data array
-  std::atomic<std::uint64_t> *Idx;            ///< CT_CPP_STD: Index array
-  uint64_t memSize;                ///< CT_CPP_STD: Memory size (in bytes)
-  uint64_t pes;                    ///< CT_CPP_STD: Number of processing elements
-  uint64_t iters;                  ///< CT_CPP_STD: Number of iterations per thread
-  uint64_t elems;                  ///< CT_CPP_STD: Number of u8 elements
-  uint64_t stride;                 ///< CT_CPP_STD: Stride in elements
+  std::atomic<std::uint64_t> *Array;    ///< CT_CPP_STD: Data array
+  std::atomic<std::uint64_t> *Idx;      ///< CT_CPP_STD: Index array
+  uint64_t memSize;                     ///< CT_CPP_STD: Memory size (in bytes)
+  uint64_t pes;                         ///< CT_CPP_STD: Number of processing elements
+  uint64_t iters;                       ///< CT_CPP_STD: Number of iterations per thread
+  uint64_t elems;                       ///< CT_CPP_STD: Number of u8 elements
+  uint64_t stride;                      ///< CT_CPP_STD: Stride in elements
 
 public:
   /// CircusTent C++ standard atomics constructor
@@ -59,7 +59,7 @@ public:
   /// CircusTent C++ standard atomics data free function
   virtual bool FreeData() override;
 
-  /// Simple barrier Implementation (avoids need for c++20 support)
+  /// Simple barrier implementation (avoids need for c++20 support)
   /// Note that barrier_ctr must be reset to 0 manually before reuse
   void MyBarrier(std::atomic<std::uint64_t> *barrier_ctr);
 

--- a/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.h
+++ b/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.h
@@ -1,0 +1,153 @@
+//
+// _CT_CPP_STD_H_
+//
+// Copyright (C) 2017-2021 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+/**
+ * \class CT_CPP_STD
+ *
+ * \ingroup CircusTent
+ *
+ * \brief CircusTent C++ Standard Atomics Implementation
+ *
+ */
+
+#ifdef _ENABLE_CPP_STD_
+
+#ifndef _CT_CPP_STD_H_
+#define _CT_CPP_STD_H_
+
+#include <cstdlib>
+#include <thread>
+#include <atomic>
+#include <ctime>
+
+#include "CircusTent/CTBaseImpl.h"
+
+class CT_CPP_STD : public CTBaseImpl{
+private:
+  std::atomic<std::uint64_t> *Array;          ///< CT_CPP_STD: Data array
+  std::atomic<std::uint64_t> *Idx;            ///< CT_CPP_STD: Index array
+  uint64_t memSize;                ///< CT_CPP_STD: Memory size (in bytes)
+  uint64_t pes;                    ///< CT_CPP_STD: Number of processing elements
+  uint64_t iters;                  ///< CT_CPP_STD: Number of iterations per thread
+  uint64_t elems;                  ///< CT_CPP_STD: Number of u8 elements
+  uint64_t stride;                 ///< CT_CPP_STD: Stride in elements
+
+public:
+  /// CircusTent C++ standard atomics constructor
+  CT_CPP_STD(CTBaseImpl::CTBenchType B,
+             CTBaseImpl::CTAtomType A);
+
+  /// CircusTent C++ standard atomics destructor
+  ~CT_CPP_STD();
+
+  /// CircusTent C++ standard atomics exeuction function
+  virtual bool Execute(double &Timing,double &GAMS) override;
+
+  /// CircusTent C++ standard atomics data allocation function
+  virtual bool AllocateData( uint64_t memSize,
+                             uint64_t pes,
+                             uint64_t iters,
+                             uint64_t stride ) override;
+
+  /// CircusTent C++ standard atomics data free function
+  virtual bool FreeData() override;
+
+  /// Simple barrier Implementation (avoids need for c++20 support)
+  /// Note that barrier_ctr must be reset to 0 manually before reuse
+  void MyBarrier(std::atomic<std::uint64_t> *barrier_ctr);
+
+  /// Helper function
+  void JoinThreads(std::thread *threads);
+
+  /// RAND AMO ADD Benchmark
+  void RAND_ADD(uint64_t thread_id,
+                std::atomic<std::uint64_t> *barrier_ctr,
+                double* start_time);
+
+  /// RAND AMO CAS Benchmark
+  void RAND_CAS(uint64_t thread_id,
+                std::atomic<std::uint64_t> *barrier_ctr,
+                double* start_time);
+
+  /// STRIDE1 AMO ADD Benchmark
+  void STRIDE1_ADD(uint64_t thread_id,
+                   std::atomic<std::uint64_t> *barrier_ctr,
+                   double* start_time);
+
+  /// STRIDE1 AMO CAS Benchmark
+  void STRIDE1_CAS(uint64_t thread_id,
+                   std::atomic<std::uint64_t> *barrier_ctr,
+                   double* start_time);
+
+  /// STRIDEN AMO ADD Benchmark
+  void STRIDEN_ADD(uint64_t thread_id,
+                   std::atomic<std::uint64_t> *barrier_ctr,
+                   double* start_time);
+
+  /// STRIDEN AMO CAS Benchmark
+  void STRIDEN_CAS(uint64_t thread_id,
+                   std::atomic<std::uint64_t> *barrier_ctr,
+                   double* start_time);
+
+  /// PTRCHASE AMO ADD Benchmark
+  void PTRCHASE_ADD(uint64_t thread_id,
+                    std::atomic<std::uint64_t> *barrier_ctr,
+                    double* start_time);
+
+  /// PTRCHASE AMO CAS Benchmark
+  void PTRCHASE_CAS(uint64_t thread_id,
+                    std::atomic<std::uint64_t> *barrier_ctr,
+                    double* start_time);
+
+  /// SG AMO ADD Benchmark
+  void SG_ADD(uint64_t thread_id,
+              std::atomic<std::uint64_t> *barrier_ctr,
+              double* start_time);
+
+  /// SG AMO CAS Benchmark
+  void SG_CAS(uint64_t thread_id,
+              std::atomic<std::uint64_t> *barrier_ctr,
+              double* start_time);
+
+  /// CENTRAL AMO ADD Benchmark
+  void CENTRAL_ADD(uint64_t thread_id,
+                   std::atomic<std::uint64_t> *barrier_ctr,
+                   double* start_time);
+
+  /// CENTRAL AMO CAS Benchmark
+  void CENTRAL_CAS(uint64_t thread_id,
+                   std::atomic<std::uint64_t> *barrier_ctr,
+                   double* start_time);
+
+  /// SCATTER AMO ADD Benchmark
+  void SCATTER_ADD(uint64_t thread_id,
+                   std::atomic<std::uint64_t> *barrier_ctr,
+                   double* start_time);
+
+  /// SCATTER AMO CAS Benchmark
+  void SCATTER_CAS(uint64_t thread_id,
+                   std::atomic<std::uint64_t> *barrier_ctr,
+                   double* start_time);
+
+  /// GATHER AMO ADD Benchmark
+  void GATHER_ADD(uint64_t thread_id,
+                  std::atomic<std::uint64_t> *barrier_ctr,
+                  double* start_time);
+
+  /// GATHER AMO CAS Benchmark
+  void GATHER_CAS(uint64_t thread_id,
+                  std::atomic<std::uint64_t> *barrier_ctr,
+                  double* start_time);
+};
+
+#endif  // _CT_CPP_STD_H_
+#endif  // _ENABLE_CPP_STD_
+
+// EOF

--- a/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD_IMPL.cpp
+++ b/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD_IMPL.cpp
@@ -245,10 +245,9 @@ void CT_CPP_STD::SG_CAS(uint64_t thread_id,
 
   // Perform atomic ops
   uint64_t src, dest, val;
-  uint64_t start = thread_id * iters;
-	val   = 0x00ull;
-	src   = 0x00ull;
-	dest  = 0x00ull;
+  val   = 0x00ull;
+  src   = 0x00ull;
+  dest  = 0x00ull;
   for(i = 0; i < iters; i++){
     Idx[start+i].compare_exchange_strong(src, Idx[start+i], std::memory_order_relaxed);
     Idx[start+i+1].compare_exchange_strong(dest, Idx[start+i+1], std::memory_order_relaxed);
@@ -316,8 +315,8 @@ void CT_CPP_STD::SCATTER_ADD(uint64_t thread_id,
   // Perform atomic ops
   uint64_t i, dest, val;
   uint64_t start = thread_id * iters;
-	val   = 0x00ull;
-	dest  = 0x00ull;
+  val   = 0x00ull;
+  dest  = 0x00ull;
   for(i = start; i < (start + iters); i++){
     dest = Idx[i+1].fetch_add((uint64_t)(0x00ull), std::memory_order_relaxed);
     val = Array[i].fetch_add((uint64_t)(0x01ull), std::memory_order_relaxed);
@@ -335,7 +334,7 @@ void CT_CPP_STD::SCATTER_CAS(uint64_t thread_id,
   uint64_t expected[iters];
   uint64_t start = thread_id * iters;
   for(i = 0; i < iters; i++){
-    expected[i] = Array[IDX[start+i+1]];
+    expected[i] = Array[Idx[start+i+1]];
   }
 
   // Wait for all threads to be spawned
@@ -348,8 +347,8 @@ void CT_CPP_STD::SCATTER_CAS(uint64_t thread_id,
 
   // Perform atomic ops
   uint64_t dest, val;
-	val   = 0x00ull;
-	dest  = 0x00ull;
+  val   = 0x00ull;
+  dest  = 0x00ull;
   for(i = 0; i < iters; i++){
     Idx[start+i+1].compare_exchange_strong(dest, Idx[start+i+1], std::memory_order_relaxed);
     Array[start+i].compare_exchange_strong(val, Array[start+i], std::memory_order_relaxed);
@@ -375,8 +374,8 @@ void CT_CPP_STD::GATHER_ADD(uint64_t thread_id,
   // Perform atomic ops
   uint64_t i, dest, val;
   uint64_t start = thread_id * iters;
-	val   = 0x00ull;
-	dest  = 0x00ull;
+  val   = 0x00ull;
+  dest  = 0x00ull;
   for(i = start; i < (start + iters); i++){
     dest = Idx[i+1].fetch_add((uint64_t)(0x00ull), std::memory_order_relaxed);
     val = Array[dest].fetch_add((uint64_t)(0x01ull), std::memory_order_relaxed);
@@ -407,8 +406,8 @@ void CT_CPP_STD::GATHER_CAS(uint64_t thread_id,
 
   // Perform atomic ops
   uint64_t dest, val;
-	val   = 0x00ull;
-	dest  = 0x00ull;
+  val   = 0x00ull;
+  dest  = 0x00ull;
   for(i = 0; i < iters; i++){
     Idx[start+i+1].compare_exchange_strong(dest, Idx[start+i+1], std::memory_order_relaxed);
     Array[dest].compare_exchange_strong(val, Array[dest], std::memory_order_relaxed);

--- a/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD_IMPL.cpp
+++ b/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD_IMPL.cpp
@@ -1,0 +1,402 @@
+/*
+ * _CT_CPP_STD_IMPL_CPP_
+ *
+ * Copyright (C) 2017-2021 Tactical Computing Laboratories, LLC
+ * All Rights Reserved
+ * contact@tactcomplabs.com
+ *
+ * See LICENSE in the top level directory for licensing details
+ */
+
+#include "CT_CPP_STD.h"
+
+/* CPP Standard Atomics Benchmark Implementations */
+
+// RAND_ADD kernel function
+void CT_CPP_STD::RAND_ADD(uint64_t thread_id,
+                          std::atomic<std::uint64_t> *barrier_ctr,
+                          double* start_time ){
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  uint64_t i;
+  uint64_t start = thread_id * iters;
+  for(i = start; i < (start + iters); i++){
+    Array[Idx[i]].fetch_add((uint64_t)(0x1), std::memory_order_relaxed);
+  }
+}
+
+// RAND_CAS kernel function
+void CT_CPP_STD::RAND_CAS(uint64_t thread_id,
+                          std::atomic<std::uint64_t> *barrier_ctr,
+                          double* start_time ){
+
+  // Set up array of expected uint64_t values to force RMW behavior
+  uint64_t i;
+  uint64_t expected[iters];
+  uint64_t start = thread_id * iters;
+  for(i = 0; i < iters; i++){
+    expected[i] = Array[Idx[start+i]];
+  }
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  for(i = 0; i < iters; i++){
+    Array[Idx[start+i]].compare_exchange_strong(expected[i], Array[Idx[start+i]], std::memory_order_relaxed);
+  }
+}
+
+// STRIDE1_ADD kernel function
+void CT_CPP_STD::STRIDE1_ADD(uint64_t thread_id,
+                             std::atomic<std::uint64_t> *barrier_ctr,
+                             double* start_time ){
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  uint64_t i;
+  uint64_t start = thread_id * iters;
+  for(i = start; i < (start + iters); i++){
+    Array[i].fetch_add((uint64_t)(0xF), std::memory_order_relaxed);
+  }
+}
+
+// STRIDE1_CAS kernel function
+void CT_CPP_STD::STRIDE1_CAS(uint64_t thread_id,
+                             std::atomic<std::uint64_t> *barrier_ctr,
+                             double* start_time ){
+
+  // Set up array of expected uint64_t values to force RMW behavior
+  uint64_t i;
+  uint64_t expected[iters];
+  uint64_t start = thread_id * iters;
+  for(i = 0; i < iters; i++){
+    expected[i] = Array[start+i];
+  }
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  for(i = 0; i < iters; i++){
+    Array[start+i].compare_exchange_strong(expected[i], Array[start+i], std::memory_order_relaxed);
+  }
+}
+
+// STRIDEN_ADD kernel function
+void CT_CPP_STD::STRIDEN_ADD(uint64_t thread_id,
+                             std::atomic<std::uint64_t> *barrier_ctr,
+                             double* start_time ){
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  uint64_t i;
+  uint64_t start = thread_id * iters;
+  for(i = start; i < (start + iters); i += stride){
+    Array[i].fetch_add((uint64_t)(0xF), std::memory_order_relaxed);
+  }
+}
+
+// STRIDEN_ADD kernel function
+void CT_CPP_STD::STRIDEN_CAS(uint64_t thread_id,
+                             std::atomic<std::uint64_t> *barrier_ctr,
+                             double* start_time ){
+
+  // Set up array of expected uint64_t values to force RMW behavior
+  uint64_t i;
+  uint64_t expected[iters];
+  uint64_t start = thread_id * iters;
+  for(i = 0; i < iters; i++){
+    expected[i] = Array[start+(stride*i)];
+  }
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  for(i = 0; i < iters; i++){
+    Array[start+(stride*i)].compare_exchange_strong(expected[i], Array[start+(stride*i)], std::memory_order_relaxed);
+  }
+}
+
+// PTRCHASE_ADD kernel function
+void CT_CPP_STD::PTRCHASE_ADD(uint64_t thread_id,
+                              std::atomic<std::uint64_t> *barrier_ctr,
+                              double* start_time ){
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  uint64_t i;
+  uint64_t start = thread_id * iters;
+  for(i = start; i < (start + iters); i++){
+    start = Idx[start].fetch_add((uint64_t)(0x00ull), std::memory_order_relaxed);
+  }
+}
+
+// PTRCHASE_CAS kernel function
+void CT_CPP_STD::PTRCHASE_CAS(uint64_t thread_id,
+                              std::atomic<std::uint64_t> *barrier_ctr,
+                              double* start_time ){
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  uint64_t i;
+  uint64_t start = thread_id * iters;
+  for(i = start; i < (start + iters); i++){
+    Idx[start].compare_exchange_strong(start, Idx[start], std::memory_order_relaxed);
+  }
+}
+
+// SG_ADD kernel function
+void CT_CPP_STD::SG_ADD(uint64_t thread_id,
+                        std::atomic<std::uint64_t> *barrier_ctr,
+                        double* start_time ){
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  uint64_t i, src, dest, val;
+  uint64_t start = thread_id * iters;
+  for(i = start; i < (start + iters); i++){
+    src = Idx[i].fetch_add((uint64_t)(0x00ull), std::memory_order_relaxed);
+    dest = Idx[i+1].fetch_add((uint64_t)(0x00ull), std::memory_order_relaxed);
+    val = Array[src].fetch_add((uint64_t)(0x01ull), std::memory_order_relaxed);
+    Array[dest].fetch_add(val, std::memory_order_relaxed);
+  }
+}
+
+// SG_CAS kernel function
+void CT_CPP_STD::SG_CAS(uint64_t thread_id,
+                        std::atomic<std::uint64_t> *barrier_ctr,
+                        double* start_time ){
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  uint64_t i, src, dest, val, expected;
+  uint64_t start = thread_id * iters;
+	val   = 0x00ull;
+	src   = 0x00ull;
+	dest  = 0x00ull;
+  for(i = start; i < (start + iters); i++){
+    Idx[i].compare_exchange_strong(src, Idx[i], std::memory_order_relaxed);
+    Idx[i+1].compare_exchange_strong(dest, Idx[i+1], std::memory_order_relaxed);
+    Array[src].compare_exchange_strong(val, Array[src], std::memory_order_relaxed);
+    expected = Array[dest];
+    Array[dest].compare_exchange_strong(expected, val, std::memory_order_relaxed);
+  }
+}
+
+// CENTRAL_ADD kernel function
+void CT_CPP_STD::CENTRAL_ADD(uint64_t thread_id,
+                             std::atomic<std::uint64_t> *barrier_ctr,
+                             double* start_time){
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  uint64_t i;
+  for(i = 0; i < iters; i++){
+    Array[0].fetch_add((uint64_t)(0x1), std::memory_order_relaxed);
+  }
+}
+
+// CENTRAL_CAS kernel function
+void CT_CPP_STD::CENTRAL_CAS(uint64_t thread_id,
+                             std::atomic<std::uint64_t> *barrier_ctr,
+                             double* start_time ){
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  uint64_t i;
+  uint64_t expected = Array[0];
+  for(i = 0; i < iters; i++){
+    Array[0].compare_exchange_strong(expected, Array[0], std::memory_order_relaxed);
+  }
+}
+
+// SCATTER_ADD kernel function
+void CT_CPP_STD::SCATTER_ADD(uint64_t thread_id,
+                             std::atomic<std::uint64_t> *barrier_ctr,
+                             double* start_time ){
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  uint64_t i, dest, val;
+  uint64_t start = thread_id * iters;
+	val   = 0x00ull;
+	dest  = 0x00ull;
+  for(i = start; i < (start + iters); i++){
+    dest = Idx[i+1].fetch_add((uint64_t)(0x00ull), std::memory_order_relaxed);
+    val = Array[i].fetch_add((uint64_t)(0x01ull), std::memory_order_relaxed);
+    Array[dest].fetch_add(val, std::memory_order_relaxed);
+  }
+}
+
+// SCATTER_CAS kernel function
+void CT_CPP_STD::SCATTER_CAS(uint64_t thread_id,
+                             std::atomic<std::uint64_t> *barrier_ctr,
+                             double* start_time ){
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  uint64_t i, dest, val, expected;
+  uint64_t start = thread_id * iters;
+	val   = 0x00ull;
+	dest  = 0x00ull;
+  for(i = start; i < (start + iters); i++){
+    Idx[i+1].compare_exchange_strong(dest, Idx[i+1], std::memory_order_relaxed);
+    Array[i].compare_exchange_strong(val, Array[i], std::memory_order_relaxed);
+    expected = Array[dest];
+    Array[dest].compare_exchange_strong(expected, val, std::memory_order_relaxed);
+  }
+}
+
+// GATHER_ADD kernel function
+void CT_CPP_STD::GATHER_ADD(uint64_t thread_id,
+                            std::atomic<std::uint64_t> *barrier_ctr,
+                            double* start_time ){
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  uint64_t i, dest, val;
+  uint64_t start = thread_id * iters;
+	val   = 0x00ull;
+	dest  = 0x00ull;
+  for(i = start; i < (start + iters); i++){
+    dest = Idx[i+1].fetch_add((uint64_t)(0x00ull), std::memory_order_relaxed);
+    val = Array[dest].fetch_add((uint64_t)(0x01ull), std::memory_order_relaxed);
+    Array[i].fetch_add(val, std::memory_order_relaxed);
+  }
+}
+
+// GATHER_CAS kernel function
+void CT_CPP_STD::GATHER_CAS(uint64_t thread_id,
+                            std::atomic<std::uint64_t> *barrier_ctr,
+                            double* start_time ){
+
+  // Set up array of expected uint64_t values to force RMW behavior
+  uint64_t i;
+  uint64_t expected[iters];
+  uint64_t start = thread_id * iters;
+  for(i = 0; i < iters; i++){
+    expected[i] = Array[start+i];
+  }
+
+  // Wait for all threads to be spawned
+  MyBarrier(barrier_ctr);
+
+  // Thread 0 write kernel StartTime
+  if(thread_id == 0){
+    *start_time = MySecond();
+  }
+
+  // Perform atomic ops
+  uint64_t dest, val;
+	val   = 0x00ull;
+	dest  = 0x00ull;
+  for(i = 0; i < iters; i++){
+    Idx[start+i+1].compare_exchange_strong(dest, Idx[start+i+1], std::memory_order_relaxed);
+    Array[dest].compare_exchange_strong(val, Array[dest], std::memory_order_relaxed);
+    Array[start+i].compare_exchange_strong(expected[i], val, std::memory_order_relaxed);
+  }
+}
+
+/* EOF */

--- a/src/CircusTent/Impl/CT_OMP_TARGET/CT_OMP_TARGET.cpp
+++ b/src/CircusTent/Impl/CT_OMP_TARGET/CT_OMP_TARGET.cpp
@@ -44,12 +44,6 @@ bool CT_OMP_TARGET::Execute(double &Timing, double &GAMS){
       EndTime   = this->MySecond();
       OPS = this->GAM(1,iters,pes);
       break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      RAND_CAS( Array, Idx, iters, pes );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(1,iters,pes);
-      break;
     default:
       this->ReportBenchError();
       return false;
@@ -60,12 +54,6 @@ bool CT_OMP_TARGET::Execute(double &Timing, double &GAMS){
     case CT_ADD:
       StartTime = this->MySecond();
       STRIDE1_ADD( Array, Idx, iters, pes );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(1,iters,pes);
-      break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      STRIDE1_CAS( Array, Idx, iters, pes );
       EndTime   = this->MySecond();
       OPS = this->GAM(1,iters,pes);
       break;
@@ -82,12 +70,6 @@ bool CT_OMP_TARGET::Execute(double &Timing, double &GAMS){
       EndTime   = this->MySecond();
       OPS = this->GAM(1,iters,pes);
       break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      STRIDEN_CAS( Array, Idx, iters, pes, stride );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(1,iters,pes);
-      break;
     default:
       this->ReportBenchError();
       return false;
@@ -98,12 +80,6 @@ bool CT_OMP_TARGET::Execute(double &Timing, double &GAMS){
     case CT_ADD:
       StartTime = this->MySecond();
       PTRCHASE_ADD( Array, Idx, iters, pes );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(1,iters,pes);
-      break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      PTRCHASE_CAS( Array, Idx, iters, pes );
       EndTime   = this->MySecond();
       OPS = this->GAM(1,iters,pes);
       break;
@@ -120,12 +96,6 @@ bool CT_OMP_TARGET::Execute(double &Timing, double &GAMS){
       EndTime   = this->MySecond();
       OPS = this->GAM(4,iters,pes);
       break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      SG_CAS( Array, Idx, iters, pes );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(4,iters,pes);
-      break;
     default:
       this->ReportBenchError();
       return false;
@@ -136,12 +106,6 @@ bool CT_OMP_TARGET::Execute(double &Timing, double &GAMS){
     case CT_ADD:
       StartTime = this->MySecond();
       CENTRAL_ADD( Array, Idx, iters, pes );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(1,iters,pes);
-      break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      CENTRAL_CAS( Array, Idx, iters, pes );
       EndTime   = this->MySecond();
       OPS = this->GAM(1,iters,pes);
       break;
@@ -158,12 +122,6 @@ bool CT_OMP_TARGET::Execute(double &Timing, double &GAMS){
       EndTime   = this->MySecond();
       OPS = this->GAM(3,iters,pes);
       break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      SCATTER_CAS( Array, Idx, iters, pes );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(3,iters,pes);
-      break;
     default:
       this->ReportBenchError();
       return false;
@@ -174,12 +132,6 @@ bool CT_OMP_TARGET::Execute(double &Timing, double &GAMS){
     case CT_ADD:
       StartTime = this->MySecond();
       GATHER_ADD( Array, Idx, iters, pes );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(3,iters,pes);
-      break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      GATHER_CAS( Array, Idx, iters, pes );
       EndTime   = this->MySecond();
       OPS = this->GAM(3,iters,pes);
       break;

--- a/src/CircusTent/Impl/CT_OMP_TARGET/CT_OMP_TARGET.h
+++ b/src/CircusTent/Impl/CT_OMP_TARGET/CT_OMP_TARGET.h
@@ -36,20 +36,8 @@ void RAND_ADD( uint64_t *ARRAY,
                uint64_t iters,
                uint64_t pes );
 
-/// RAND AMO CAS Benchmark
-void RAND_CAS( uint64_t *ARRAY,
-               uint64_t *IDX,
-               uint64_t iters,
-               uint64_t pes );
-
 /// STRIDE1 AMO ADD Benchmark
 void STRIDE1_ADD( uint64_t *ARRAY,
-                  uint64_t *IDX,
-                  uint64_t iters,
-                  uint64_t pes );
-
-/// STRIDE1 AMO CAS Benchmark
-void STRIDE1_CAS( uint64_t *ARRAY,
                   uint64_t *IDX,
                   uint64_t iters,
                   uint64_t pes );
@@ -61,21 +49,8 @@ void STRIDEN_ADD( uint64_t *ARRAY,
                   uint64_t pes,
                   uint64_t stride );
 
-/// STRIDEN AMO CAS Benchmark
-void STRIDEN_CAS( uint64_t *ARRAY,
-                  uint64_t *IDX,
-                  uint64_t iters,
-                  uint64_t pes,
-                  uint64_t stride );
-
 /// PTRCHASE AMO ADD Benchmark
 void PTRCHASE_ADD( uint64_t *ARRAY,
-                   uint64_t *IDX,
-                   uint64_t iters,
-                   uint64_t pes );
-
-/// PTRCHASE AMO CAS Benchmark
-void PTRCHASE_CAS( uint64_t *ARRAY,
                    uint64_t *IDX,
                    uint64_t iters,
                    uint64_t pes );
@@ -86,20 +61,8 @@ void SG_ADD( uint64_t *ARRAY,
              uint64_t iters,
              uint64_t pes );
 
-/// SG AMO CAS Benchmark
-void SG_CAS( uint64_t *ARRAY,
-             uint64_t *IDX,
-             uint64_t iters,
-             uint64_t pes );
-
 /// CENTRAL AMO ADD Benchmark
 void CENTRAL_ADD( uint64_t *ARRAY,
-                  uint64_t *IDX,
-                  uint64_t iters,
-                  uint64_t pes );
-
-/// CENTRAL AMO CAS Benchmark
-void CENTRAL_CAS( uint64_t *ARRAY,
                   uint64_t *IDX,
                   uint64_t iters,
                   uint64_t pes );
@@ -110,20 +73,8 @@ void SCATTER_ADD( uint64_t *ARRAY,
                   uint64_t iters,
                   uint64_t pes );
 
-/// SCATTER AMO CAS Benchmark
-void SCATTER_CAS( uint64_t *ARRAY,
-                  uint64_t *IDX,
-                  uint64_t iters,
-                  uint64_t pes );
-
 /// GATHER AMO ADD Benchmark
 void GATHER_ADD( uint64_t *ARRAY,
-                 uint64_t *IDX,
-                 uint64_t iters,
-                 uint64_t pes );
-
-/// GATHER AMO CAS Benchmark
-void GATHER_CAS( uint64_t *ARRAY,
                  uint64_t *IDX,
                  uint64_t iters,
                  uint64_t pes );

--- a/src/CircusTent/Impl/CT_OMP_TARGET/CT_OMP_TARGET_IMPL.c
+++ b/src/CircusTent/Impl/CT_OMP_TARGET/CT_OMP_TARGET_IMPL.c
@@ -40,35 +40,13 @@ void RAND_ADD( uint64_t *restrict ARRAY,
       uint64_t start = (uint64_t) ( (omp_get_team_num() * iters) +
                                     (omp_get_thread_num() * (iters/num_threads)) );
 
+      uint64_t ret;
       for( i=start; i<(start+iters_per_thread); i++ ){
-        __atomic_fetch_add( &ARRAY[IDX[i]], (uint64_t)(0x1), __ATOMIC_RELAXED );
-      }
-    }
-  }
-}
-
-void RAND_CAS( uint64_t *restrict ARRAY,
-               uint64_t *restrict IDX,
-               uint64_t iters,
-               uint64_t pes ){
-
-  #pragma omp target teams num_teams(pes) is_device_ptr(ARRAY, IDX) map(to:iters, pes)
-  {
-    #pragma omp parallel
-    {
-      uint64_t i = 0;
-
-      // Divide iters across number of threads per team & set start
-      uint64_t num_threads = (uint64_t) omp_get_num_threads();
-      uint64_t iters_per_thread = (omp_get_thread_num() == num_threads - 1) ?
-                                  (iters / num_threads) + (iters % num_threads) :
-                                  (iters / num_threads);
-      uint64_t start = (uint64_t) ( (omp_get_team_num() * iters) +
-                                    (omp_get_thread_num() * (iters/num_threads)) );
-
-      for( i=start; i<(start+iters_per_thread); i++ ){
-        __atomic_compare_exchange_n( &ARRAY[IDX[i]], &ARRAY[IDX[i]], ARRAY[IDX[i]],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma omp atomic capture relaxed
+        {
+          ret = ARRAY[IDX[i]];
+          ARRAY[IDX[i]] += 1;
+        }
       }
     }
   }
@@ -93,35 +71,13 @@ void STRIDE1_ADD( uint64_t *restrict ARRAY,
       uint64_t start = (uint64_t) ( (omp_get_team_num() * iters) +
                                     (omp_get_thread_num() * (iters/num_threads)) );
 
+      uint64_t ret;
       for( i=start; i<(start+iters_per_thread); i++ ){
-        __atomic_fetch_add( &ARRAY[i], (uint64_t)(0xF), __ATOMIC_RELAXED );
-      }
-    }
-  }
-}
-
-void STRIDE1_CAS( uint64_t *restrict ARRAY,
-                  uint64_t *restrict IDX,
-                  uint64_t iters,
-                  uint64_t pes ){
-
-  #pragma omp target teams num_teams(pes) is_device_ptr(ARRAY, IDX) map(to:iters, pes)
-  {
-    #pragma omp parallel
-    {
-      uint64_t i = 0;
-
-      // Divide iters across number of threads per team & set start
-      uint64_t num_threads = (uint64_t) omp_get_num_threads();
-      uint64_t iters_per_thread = (omp_get_thread_num() == num_threads - 1) ?
-                                  (iters / num_threads) + (iters % num_threads) :
-                                  (iters / num_threads);
-      uint64_t start = (uint64_t) ( (omp_get_team_num() * iters) +
-                                    (omp_get_thread_num() * (iters/num_threads)) );
-
-      for( i=start; i<(start+iters_per_thread); i++ ){
-        __atomic_compare_exchange_n( &ARRAY[i], &ARRAY[i], ARRAY[i],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma omp atomic capture relaxed
+        {
+          ret = ARRAY[i];
+          ARRAY[i] += 1;
+        }
       }
     }
   }
@@ -147,36 +103,13 @@ void STRIDEN_ADD( uint64_t *restrict ARRAY,
       uint64_t start = (uint64_t) ( (omp_get_team_num() * iters) +
                                     (omp_get_thread_num() * (iters/num_threads) * stride) );
 
+      uint64_t ret;
       for( i=start; i<(start+iters_per_thread); i+=stride ){
-        __atomic_fetch_add( &ARRAY[i], (uint64_t)(0xF), __ATOMIC_RELAXED );
-      }
-    }
-  }
-}
-
-void STRIDEN_CAS( uint64_t *restrict ARRAY,
-                  uint64_t *restrict IDX,
-                  uint64_t iters,
-                  uint64_t pes,
-                  uint64_t stride ){
-
-  #pragma omp target teams num_teams(pes) is_device_ptr(ARRAY, IDX) map(to:iters, pes, stride)
-  {
-    #pragma omp parallel
-    {
-      uint64_t i = 0;
-
-      // Divide iters across number of threads per team & set start
-      uint64_t num_threads = (uint64_t) omp_get_num_threads();
-      uint64_t iters_per_thread = (omp_get_thread_num() == num_threads - 1) ?
-                                  (iters / num_threads) + (iters % num_threads) :
-                                  (iters / num_threads);
-      uint64_t start = (uint64_t) ( (omp_get_team_num() * iters) +
-                                    (omp_get_thread_num() * (iters/num_threads) * stride) );
-
-      for( i=start; i<(start+iters_per_thread); i+=stride ){
-        __atomic_compare_exchange_n( &ARRAY[i], &ARRAY[i], ARRAY[i],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma omp atomic capture relaxed
+        {
+          ret = ARRAY[i];
+          ARRAY[i] += 1;
+        }
       }
     }
   }
@@ -202,36 +135,11 @@ void PTRCHASE_ADD( uint64_t *restrict ARRAY,
                                     (omp_get_thread_num() * (iters/num_threads)) );
 
       for( i=0; i<iters_per_thread; i++ ){
-        start = __atomic_fetch_add( &IDX[start],
-                                    (uint64_t)(0x00ull),
-                                    __ATOMIC_RELAXED );
-      }
-    }
-  }
-}
-
-void PTRCHASE_CAS( uint64_t *restrict ARRAY,
-                   uint64_t *restrict IDX,
-                   uint64_t iters,
-                   uint64_t pes ){
-
-  #pragma omp target teams num_teams(pes) is_device_ptr(ARRAY, IDX) map(to:iters, pes)
-  {
-    #pragma omp parallel
-    {
-      uint64_t i = 0;
-
-      // Divide iters across number of threads per team & set start
-      uint64_t num_threads = (uint64_t) omp_get_num_threads();
-      uint64_t iters_per_thread = (omp_get_thread_num() == num_threads - 1) ?
-                                  (iters / num_threads) + (iters % num_threads) :
-                                  (iters / num_threads);
-      uint64_t start = (uint64_t) ( (omp_get_team_num() * iters) +
-                                    (omp_get_thread_num() * (iters/num_threads)) );
-
-      for( i=0; i<iters_per_thread; i++ ){
-        __atomic_compare_exchange_n( &IDX[start], &start, IDX[start],
-                                    0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma omp atomic capture relaxed
+        {
+          start = IDX[start];
+          IDX[start] += 0;
+        }
       }
     }
   }
@@ -259,47 +167,31 @@ void SG_ADD( uint64_t *restrict ARRAY,
       uint64_t start = (uint64_t) ( (omp_get_team_num() * iters) +
                                     (omp_get_thread_num() * (iters/num_threads)) );
 
+      uint64_t ret;
       for( i=start; i<(start+iters_per_thread); i++ ){
-        src  = __atomic_fetch_add( &IDX[i], (uint64_t)(0x00ull), __ATOMIC_RELAXED );
-        dest = __atomic_fetch_add( &IDX[i+1], (uint64_t)(0x00ull), __ATOMIC_RELAXED );
-        val = __atomic_fetch_add( &ARRAY[src], (uint64_t)(0x01ull), __ATOMIC_RELAXED );
-        __atomic_fetch_add( &ARRAY[dest], val, __ATOMIC_RELAXED );
-      }
-    }
-  }
-}
+        #pragma omp atomic capture relaxed
+        {
+          src = IDX[i];
+          IDX[i] += 0;
+        }
 
-void SG_CAS( uint64_t *restrict ARRAY,
-             uint64_t *restrict IDX,
-             uint64_t iters,
-             uint64_t pes ){
+        #pragma omp atomic capture relaxed
+        {
+          dest = IDX[i+1];
+          IDX[i+1] += 0;
+        }
 
-  #pragma omp target teams num_teams(pes) is_device_ptr(ARRAY, IDX) map(to:iters, pes)
-  {
-    #pragma omp parallel
-    {
-      uint64_t i = 0;
-      uint64_t src = 0;
-      uint64_t dest = 0;
-      uint64_t val = 0;
+        #pragma omp atomic capture relaxed
+        {
+          val = ARRAY[src];
+          ARRAY[src] += 1;
+        }
 
-      // Divide iters across number of threads per team & set start
-      uint64_t num_threads = (uint64_t) omp_get_num_threads();
-      uint64_t iters_per_thread = (omp_get_thread_num() == num_threads - 1) ?
-                                  (iters / num_threads) + (iters % num_threads) :
-                                  (iters / num_threads);
-      uint64_t start = (uint64_t) ( (omp_get_team_num() * iters) +
-                                    (omp_get_thread_num() * (iters/num_threads)) );
-
-      for( i=start; i<(start+iters_per_thread); i++ ){
-      __atomic_compare_exchange_n( &IDX[i], &src, IDX[i],
-                                   0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-      __atomic_compare_exchange_n( &IDX[i+1], &dest, IDX[i+1],
-                                   0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-      __atomic_compare_exchange_n( &ARRAY[src], &val, ARRAY[src],
-                                   0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-      __atomic_compare_exchange_n( &ARRAY[dest], &ARRAY[dest], val,
-                                   0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma omp atomic capture relaxed
+        {
+          ret = ARRAY[dest];
+          ARRAY[dest] += val;
+        }
       }
     }
   }
@@ -322,33 +214,13 @@ void CENTRAL_ADD( uint64_t *restrict ARRAY,
                                   (iters / num_threads) + (iters % num_threads) :
                                   (iters / num_threads);
 
+      uint64_t ret;
       for( i=0; i<iters_per_thread; i++ ){
-        __atomic_fetch_add( &ARRAY[0], (uint64_t)(0x1), __ATOMIC_RELAXED );
-      }
-    }
-  }
-}
-
-void CENTRAL_CAS( uint64_t *restrict ARRAY,
-                  uint64_t *restrict IDX,
-                  uint64_t iters,
-                  uint64_t pes ){
-
-  #pragma omp target teams num_teams(pes) is_device_ptr(ARRAY, IDX) map(to:iters, pes)
-  {
-    #pragma omp parallel
-    {
-      uint64_t i = 0;
-
-      // Divide iters across number of threads per team & set start
-      uint64_t num_threads = (uint64_t) omp_get_num_threads();
-      uint64_t iters_per_thread = (omp_get_thread_num() == num_threads - 1) ?
-                                  (iters / num_threads) + (iters % num_threads) :
-                                  (iters / num_threads);
-
-      for( i=0; i<iters_per_thread; i++ ){
-        __atomic_compare_exchange_n( &ARRAY[0], &ARRAY[0], ARRAY[0],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma omp atomic capture relaxed
+        {
+          ret = ARRAY[0];
+          ARRAY[0] += 1;
+        }
       }
     }
   }
@@ -375,43 +247,25 @@ void SCATTER_ADD( uint64_t *restrict ARRAY,
       uint64_t start = (uint64_t) ( (omp_get_team_num() * iters) +
                                     (omp_get_thread_num() * (iters/num_threads)) );
 
+      uint64_t ret;
       for( i=start; i<(start+iters_per_thread); i++ ){
-        dest = __atomic_fetch_add( &IDX[i+1], (uint64_t)(0x00ull), __ATOMIC_RELAXED );
-        val = __atomic_fetch_add( &ARRAY[i], (uint64_t)(0x01ull), __ATOMIC_RELAXED );
-        __atomic_fetch_add( &ARRAY[dest], val, __ATOMIC_RELAXED );
-      }
-    }
-  }
-}
+        #pragma omp atomic capture relaxed
+        {
+          dest = IDX[i+1];
+          IDX[i+1] += 0;
+        }
 
-void SCATTER_CAS( uint64_t *restrict ARRAY,
-                  uint64_t *restrict IDX,
-                  uint64_t iters,
-                  uint64_t pes ){
+        #pragma omp atomic capture relaxed
+        {
+          val = ARRAY[i];
+          ARRAY[i] += 1;
+        }
 
-  #pragma omp target teams num_teams(pes) is_device_ptr(ARRAY, IDX) map(to:iters, pes)
-  {
-    #pragma omp parallel
-    {
-      uint64_t i = 0;
-      uint64_t dest = 0;
-      uint64_t val = 0;
-
-      // Divide iters across number of threads per team & set start
-      uint64_t num_threads = (uint64_t) omp_get_num_threads();
-      uint64_t iters_per_thread = (omp_get_thread_num() == num_threads - 1) ?
-                                  (iters / num_threads) + (iters % num_threads) :
-                                  (iters / num_threads);
-      uint64_t start = (uint64_t) ( (omp_get_team_num() * iters) +
-                                    (omp_get_thread_num() * (iters/num_threads)) );
-
-      for( i=start; i<(start+iters_per_thread); i++ ){
-        __atomic_compare_exchange_n( &IDX[i+1], &dest, IDX[i+1],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-        __atomic_compare_exchange_n( &ARRAY[i], &val, ARRAY[i],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-        __atomic_compare_exchange_n( &ARRAY[dest], &ARRAY[dest], val,
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma omp atomic capture relaxed
+        {
+          ret = ARRAY[dest];
+          ARRAY[dest] += val;
+        }
       }
     }
   }
@@ -438,44 +292,25 @@ void GATHER_ADD( uint64_t *restrict ARRAY,
       uint64_t start = (uint64_t) ( (omp_get_team_num() * iters) +
                                     (omp_get_thread_num() * (iters/num_threads)) );
 
+      uint64_t ret;
       for( i=start; i<(start+iters_per_thread); i++ ){
-        dest = __atomic_fetch_add( &IDX[i+1], (uint64_t)(0x00ull), __ATOMIC_RELAXED );
-        val = __atomic_fetch_add( &ARRAY[dest], (uint64_t)(0x01ull), __ATOMIC_RELAXED );
-        __atomic_fetch_add( &ARRAY[i], val, __ATOMIC_RELAXED );
-      }
-    }
-  }
-}
+        #pragma omp atomic capture relaxed
+        {
+          dest = IDX[i+1];
+          IDX[i+1] += 0;
+        }
 
-void GATHER_CAS( uint64_t *restrict ARRAY,
-                 uint64_t *restrict IDX,
-                 uint64_t iters,
-                 uint64_t pes ){
+        #pragma omp atomic capture relaxed
+        {
+          val = ARRAY[dest];
+          ARRAY[dest] += 1;
+        }
 
-  #pragma omp target teams num_teams(pes) is_device_ptr(ARRAY, IDX) map(to:iters, pes)
-  {
-    #pragma omp parallel
-    {
-      uint64_t i = 0;
-      uint64_t dest = 0;
-      uint64_t val = 0;
-
-      // Divide iters across number of threads per team & set start
-      uint64_t num_threads = (uint64_t) omp_get_num_threads();
-      uint64_t iters_per_thread = (omp_get_thread_num() == num_threads - 1) ?
-                                  (iters / num_threads) + (iters % num_threads) :
-                                  (iters / num_threads);
-      uint64_t start = (uint64_t) ( (omp_get_team_num() * iters) +
-                                    (omp_get_thread_num() * (iters/num_threads)) );
-
-
-      for( i=start; i<(start+iters_per_thread); i++ ){
-        __atomic_compare_exchange_n( &IDX[i+1], &dest, IDX[i+1],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-        __atomic_compare_exchange_n( &ARRAY[dest], &val, ARRAY[dest],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-        __atomic_compare_exchange_n( &ARRAY[i], &ARRAY[i], val,
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma omp atomic capture relaxed
+        {
+          ret = ARRAY[i];
+          ARRAY[i] += val;
+        }
       }
     }
   }

--- a/src/CircusTent/Impl/CT_OMP_TARGET/CT_OMP_TARGET_IMPL.c
+++ b/src/CircusTent/Impl/CT_OMP_TARGET/CT_OMP_TARGET_IMPL.c
@@ -42,7 +42,7 @@ void RAND_ADD( uint64_t *restrict ARRAY,
 
       uint64_t ret;
       for( i=start; i<(start+iters_per_thread); i++ ){
-        #pragma omp atomic capture relaxed
+        #pragma omp atomic capture
         {
           ret = ARRAY[IDX[i]];
           ARRAY[IDX[i]] += 1;
@@ -73,7 +73,7 @@ void STRIDE1_ADD( uint64_t *restrict ARRAY,
 
       uint64_t ret;
       for( i=start; i<(start+iters_per_thread); i++ ){
-        #pragma omp atomic capture relaxed
+        #pragma omp atomic capture
         {
           ret = ARRAY[i];
           ARRAY[i] += 1;
@@ -105,7 +105,7 @@ void STRIDEN_ADD( uint64_t *restrict ARRAY,
 
       uint64_t ret;
       for( i=start; i<(start+iters_per_thread); i+=stride ){
-        #pragma omp atomic capture relaxed
+        #pragma omp atomic capture
         {
           ret = ARRAY[i];
           ARRAY[i] += 1;
@@ -135,7 +135,7 @@ void PTRCHASE_ADD( uint64_t *restrict ARRAY,
                                     (omp_get_thread_num() * (iters/num_threads)) );
 
       for( i=0; i<iters_per_thread; i++ ){
-        #pragma omp atomic capture relaxed
+        #pragma omp atomic capture
         {
           start = IDX[start];
           IDX[start] += 0;
@@ -169,25 +169,25 @@ void SG_ADD( uint64_t *restrict ARRAY,
 
       uint64_t ret;
       for( i=start; i<(start+iters_per_thread); i++ ){
-        #pragma omp atomic capture relaxed
+        #pragma omp atomic capture
         {
           src = IDX[i];
           IDX[i] += 0;
         }
 
-        #pragma omp atomic capture relaxed
+        #pragma omp atomic capture
         {
           dest = IDX[i+1];
           IDX[i+1] += 0;
         }
 
-        #pragma omp atomic capture relaxed
+        #pragma omp atomic capture
         {
           val = ARRAY[src];
           ARRAY[src] += 1;
         }
 
-        #pragma omp atomic capture relaxed
+        #pragma omp atomic capture
         {
           ret = ARRAY[dest];
           ARRAY[dest] += val;
@@ -216,7 +216,7 @@ void CENTRAL_ADD( uint64_t *restrict ARRAY,
 
       uint64_t ret;
       for( i=0; i<iters_per_thread; i++ ){
-        #pragma omp atomic capture relaxed
+        #pragma omp atomic capture
         {
           ret = ARRAY[0];
           ARRAY[0] += 1;
@@ -249,19 +249,19 @@ void SCATTER_ADD( uint64_t *restrict ARRAY,
 
       uint64_t ret;
       for( i=start; i<(start+iters_per_thread); i++ ){
-        #pragma omp atomic capture relaxed
+        #pragma omp atomic capture
         {
           dest = IDX[i+1];
           IDX[i+1] += 0;
         }
 
-        #pragma omp atomic capture relaxed
+        #pragma omp atomic capture
         {
           val = ARRAY[i];
           ARRAY[i] += 1;
         }
 
-        #pragma omp atomic capture relaxed
+        #pragma omp atomic capture
         {
           ret = ARRAY[dest];
           ARRAY[dest] += val;
@@ -294,19 +294,19 @@ void GATHER_ADD( uint64_t *restrict ARRAY,
 
       uint64_t ret;
       for( i=start; i<(start+iters_per_thread); i++ ){
-        #pragma omp atomic capture relaxed
-        {
+        #pragma omp atomic capture
+      	{
           dest = IDX[i+1];
           IDX[i+1] += 0;
         }
 
-        #pragma omp atomic capture relaxed
+        #pragma omp atomic capture
         {
           val = ARRAY[dest];
           ARRAY[dest] += 1;
         }
 
-        #pragma omp atomic capture relaxed
+        #pragma omp atomic capture
         {
           ret = ARRAY[i];
           ARRAY[i] += val;

--- a/src/CircusTent/Impl/CT_OPENACC/CT_OPENACC.cpp
+++ b/src/CircusTent/Impl/CT_OPENACC/CT_OPENACC.cpp
@@ -45,12 +45,6 @@ bool CT_OPENACC::Execute(double &Timing, double &GAMS){
       EndTime   = this->MySecond();
       OPS = this->GAM(1,iters,pes);
       break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      RAND_CAS( Array, Idx, iters, pes );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(1,iters,pes);
-      break;
     default:
       this->ReportBenchError();
       return false;
@@ -61,12 +55,6 @@ bool CT_OPENACC::Execute(double &Timing, double &GAMS){
     case CT_ADD:
       StartTime = this->MySecond();
       STRIDE1_ADD( Array, Idx, iters, pes );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(1,iters,pes);
-      break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      STRIDE1_CAS( Array, Idx, iters, pes );
       EndTime   = this->MySecond();
       OPS = this->GAM(1,iters,pes);
       break;
@@ -83,12 +71,6 @@ bool CT_OPENACC::Execute(double &Timing, double &GAMS){
       EndTime   = this->MySecond();
       OPS = this->GAM(1,iters,pes);
       break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      STRIDEN_CAS( Array, Idx, iters, pes, stride );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(1,iters,pes);
-      break;
     default:
       this->ReportBenchError();
       return false;
@@ -99,12 +81,6 @@ bool CT_OPENACC::Execute(double &Timing, double &GAMS){
     case CT_ADD:
       StartTime = this->MySecond();
       PTRCHASE_ADD( Array, Idx, iters, pes );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(1,iters,pes);
-      break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      PTRCHASE_CAS( Array, Idx, iters, pes );
       EndTime   = this->MySecond();
       OPS = this->GAM(1,iters,pes);
       break;
@@ -121,12 +97,6 @@ bool CT_OPENACC::Execute(double &Timing, double &GAMS){
       EndTime   = this->MySecond();
       OPS = this->GAM(4,iters,pes);
       break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      SG_CAS( Array, Idx, iters, pes );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(4,iters,pes);
-      break;
     default:
       this->ReportBenchError();
       return false;
@@ -137,12 +107,6 @@ bool CT_OPENACC::Execute(double &Timing, double &GAMS){
     case CT_ADD:
       StartTime = this->MySecond();
       CENTRAL_ADD( Array, Idx, iters, pes );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(1,iters,pes);
-      break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      CENTRAL_CAS( Array, Idx, iters, pes );
       EndTime   = this->MySecond();
       OPS = this->GAM(1,iters,pes);
       break;
@@ -159,12 +123,6 @@ bool CT_OPENACC::Execute(double &Timing, double &GAMS){
       EndTime   = this->MySecond();
       OPS = this->GAM(3,iters,pes);
       break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      SCATTER_CAS( Array, Idx, iters, pes );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(3,iters,pes);
-      break;
     default:
       this->ReportBenchError();
       return false;
@@ -175,12 +133,6 @@ bool CT_OPENACC::Execute(double &Timing, double &GAMS){
     case CT_ADD:
       StartTime = this->MySecond();
       GATHER_ADD( Array, Idx, iters, pes );
-      EndTime   = this->MySecond();
-      OPS = this->GAM(3,iters,pes);
-      break;
-    case CT_CAS:
-      StartTime = this->MySecond();
-      GATHER_CAS( Array, Idx, iters, pes );
       EndTime   = this->MySecond();
       OPS = this->GAM(3,iters,pes);
       break;

--- a/src/CircusTent/Impl/CT_OPENACC/CT_OPENACC.h
+++ b/src/CircusTent/Impl/CT_OPENACC/CT_OPENACC.h
@@ -36,20 +36,8 @@ void RAND_ADD( uint64_t *ARRAY,
                uint64_t iters,
                uint64_t pes );
 
-/// RAND AMO CAS Benchmark
-void RAND_CAS( uint64_t *ARRAY,
-               uint64_t *IDX,
-               uint64_t iters,
-               uint64_t pes );
-
 /// STRIDE1 AMO ADD Benchmark
 void STRIDE1_ADD( uint64_t *ARRAY,
-                  uint64_t *IDX,
-                  uint64_t iters,
-                  uint64_t pes );
-
-/// STRIDE1 AMO CAS Benchmark
-void STRIDE1_CAS( uint64_t *ARRAY,
                   uint64_t *IDX,
                   uint64_t iters,
                   uint64_t pes );
@@ -61,21 +49,8 @@ void STRIDEN_ADD( uint64_t *ARRAY,
                   uint64_t pes,
                   uint64_t stride );
 
-/// STRIDEN AMO CAS Benchmark
-void STRIDEN_CAS( uint64_t *ARRAY,
-                  uint64_t *IDX,
-                  uint64_t iters,
-                  uint64_t pes,
-                  uint64_t stride );
-
 /// PTRCHASE AMO ADD Benchmark
 void PTRCHASE_ADD( uint64_t *ARRAY,
-                   uint64_t *IDX,
-                   uint64_t iters,
-                   uint64_t pes );
-
-/// PTRCHASE AMO CAS Benchmark
-void PTRCHASE_CAS( uint64_t *ARRAY,
                    uint64_t *IDX,
                    uint64_t iters,
                    uint64_t pes );
@@ -86,20 +61,8 @@ void SG_ADD( uint64_t *ARRAY,
              uint64_t iters,
              uint64_t pes );
 
-/// SG AMO CAS Benchmark
-void SG_CAS( uint64_t *ARRAY,
-             uint64_t *IDX,
-             uint64_t iters,
-             uint64_t pes );
-
 /// CENTRAL AMO ADD Benchmark
 void CENTRAL_ADD( uint64_t *ARRAY,
-                  uint64_t *IDX,
-                  uint64_t iters,
-                  uint64_t pes );
-
-/// CENTRAL AMO CAS Benchmark
-void CENTRAL_CAS( uint64_t *ARRAY,
                   uint64_t *IDX,
                   uint64_t iters,
                   uint64_t pes );
@@ -110,26 +73,13 @@ void SCATTER_ADD( uint64_t *ARRAY,
                   uint64_t iters,
                   uint64_t pes );
 
-/// SCATTER AMO CAS Benchmark
-void SCATTER_CAS( uint64_t *ARRAY,
-                  uint64_t *IDX,
-                  uint64_t iters,
-                  uint64_t pes );
-
 /// GATHER AMO ADD Benchmark
 void GATHER_ADD( uint64_t *ARRAY,
                  uint64_t *IDX,
                  uint64_t iters,
                  uint64_t pes );
 
-/// GATHER AMO CAS Benchmark
-void GATHER_CAS( uint64_t *ARRAY,
-                 uint64_t *IDX,
-                 uint64_t iters,
-                 uint64_t pes );
-
 }
-
 
 class CT_OPENACC : public CTBaseImpl{
 private:

--- a/src/CircusTent/Impl/CT_OPENACC/CT_OPENACC_IMPL.c
+++ b/src/CircusTent/Impl/CT_OPENACC/CT_OPENACC_IMPL.c
@@ -35,36 +35,21 @@ void RAND_ADD( uint64_t *restrict ARRAY,
       uint64_t i = 0;
 
       // Atomic F&A to order gangs
-      uint64_t gangID = __atomic_fetch_add(&gangCtr, (uint64_t)(0x1), __ATOMIC_RELAXED);
-      uint64_t start = gangID * iters;
-
-      for( i=start; i<(start+iters); i++ ){
-        __atomic_fetch_add( &ARRAY[IDX[i]], (uint64_t)(0x1), __ATOMIC_RELAXED );
+      uint64_t gangID;
+      #pragma acc atomic capture
+      {
+        gangID = gangCtr;
+        gangCtr++;
       }
-    }
-  }
-}
-
-void RAND_CAS( uint64_t *restrict ARRAY,
-               uint64_t *restrict IDX,
-               uint64_t iters,
-               uint64_t pes ){
-
-  #pragma acc data deviceptr(ARRAY, IDX) copyin(iters, pes)
-  {
-    // target global variable for assigning gang IDs
-    uint64_t gangCtr = 0;
-    #pragma acc parallel num_gangs(pes)
-    {
-      uint64_t i = 0;
-
-      // Atomic F&A to order gangs
-      uint64_t gangID = __atomic_fetch_add(&gangCtr, (uint64_t)(0x1), __ATOMIC_RELAXED);
       uint64_t start = gangID * iters;
 
+      uint64_t ret;
       for( i=start; i<(start+iters); i++ ){
-        __atomic_compare_exchange_n( &ARRAY[IDX[i]], &ARRAY[IDX[i]], ARRAY[IDX[i]],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma acc atomic capture
+        {
+          ret = ARRAY[IDX[i]];
+          ARRAY[IDX[i]] += 1;
+        }
       }
     }
   }
@@ -84,35 +69,21 @@ void STRIDE1_ADD( uint64_t *restrict ARRAY,
       uint64_t i = 0;
 
       // Atomic F&A to order gangs
-      uint64_t gangID = __atomic_fetch_add(&gangCtr, (uint64_t)(0x1), __ATOMIC_RELAXED);
-      uint64_t start = gangID * iters;
-
-      for( i=start; i<(start+iters); i++ ){
-        __atomic_fetch_add( &ARRAY[i], (uint64_t)(0xF), __ATOMIC_RELAXED );
+      uint64_t gangID;
+      #pragma acc atomic capture
+      {
+        gangID = gangCtr;
+        gangCtr++;
       }
-    }
-  }
-}
-
-void STRIDE1_CAS( uint64_t *restrict ARRAY,
-                  uint64_t *restrict IDX,
-                  uint64_t iters,
-                  uint64_t pes ){
-  #pragma acc data deviceptr(ARRAY, IDX) copyin(iters, pes)
-  {
-    // target global variable for assigning gang IDs
-    uint64_t gangCtr = 0;
-    #pragma acc parallel num_gangs(pes)
-    {
-      uint64_t i = 0;
-
-      // Atomic F&A to order gangs
-      uint64_t gangID = __atomic_fetch_add(&gangCtr, (uint64_t)(0x1), __ATOMIC_RELAXED);
       uint64_t start = gangID * iters;
 
+      uint64_t ret;
       for( i=start; i<(start+iters); i++ ){
-        __atomic_compare_exchange_n( &ARRAY[i], &ARRAY[i], ARRAY[i],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma acc atomic capture
+        {
+          ret = ARRAY[i];
+          ARRAY[i] += 1;
+        }
       }
     }
   }
@@ -133,37 +104,21 @@ void STRIDEN_ADD( uint64_t *restrict ARRAY,
       uint64_t i = 0;
 
       // Atomic F&A to order gangs
-      uint64_t gangID = __atomic_fetch_add(&gangCtr, (uint64_t)(0x1), __ATOMIC_RELAXED);
-      uint64_t start = gangID * iters;
-
-      for( i=start; i<(start+iters); i+=stride ){
-        __atomic_fetch_add( &ARRAY[i], (uint64_t)(0xF), __ATOMIC_RELAXED );
+      uint64_t gangID;
+      #pragma acc atomic capture
+      {
+        gangID = gangCtr;
+        gangCtr++;
       }
-    }
-  }
-}
-
-void STRIDEN_CAS( uint64_t *restrict ARRAY,
-                  uint64_t *restrict IDX,
-                  uint64_t iters,
-                  uint64_t pes,
-                  uint64_t stride ){
-
-  #pragma acc data deviceptr(ARRAY, IDX) copyin(iters, pes, stride)
-  {
-    // target global variable for assigning gang IDs
-    uint64_t gangCtr = 0;
-    #pragma acc parallel num_gangs(pes)
-    {
-      uint64_t i = 0;
-
-      // Atomic F&A to order gangs
-      uint64_t gangID = __atomic_fetch_add(&gangCtr, (uint64_t)(0x1), __ATOMIC_RELAXED);
       uint64_t start = gangID * iters;
 
+      uint64_t ret;
       for( i=start; i<(start+iters); i+=stride ){
-        __atomic_compare_exchange_n( &ARRAY[i], &ARRAY[i], ARRAY[i],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma acc atomic capture
+        {
+          ret = ARRAY[i];
+          ARRAY[i] += 1;
+        }
       }
     }
   }
@@ -183,38 +138,20 @@ void PTRCHASE_ADD( uint64_t *restrict ARRAY,
       uint64_t i = 0;
 
       // Atomic F&A to order gangs
-      uint64_t gangID = __atomic_fetch_add(&gangCtr, (uint64_t)(0x1), __ATOMIC_RELAXED);
-      uint64_t start = gangID * iters;
-
-      for( i=0; i<iters; i++ ){
-        start = __atomic_fetch_add( &IDX[start],
-                                    (uint64_t)(0x00ull),
-                                    __ATOMIC_RELAXED);
+      uint64_t gangID;
+      #pragma acc atomic capture
+      {
+        gangID = gangCtr;
+        gangCtr++;
       }
-    }
-  }
-}
-
-void PTRCHASE_CAS( uint64_t *restrict ARRAY,
-                   uint64_t *restrict IDX,
-                   uint64_t iters,
-                   uint64_t pes ){
-
-  #pragma acc data deviceptr(ARRAY, IDX) copyin(iters, pes)
-  {
-    // target global variable for assigning gang IDs
-    uint64_t gangCtr = 0;
-    #pragma acc parallel num_gangs(pes)
-    {
-      uint64_t i = 0;
-
-      // Atomic F&A to order gangs
-      uint64_t gangID = __atomic_fetch_add(&gangCtr, (uint64_t)(0x1), __ATOMIC_RELAXED);
       uint64_t start = gangID * iters;
 
       for( i=0; i<iters; i++ ){
-        __atomic_compare_exchange_n( &IDX[start], &start, IDX[start],
-                                    0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma acc atomic capture
+        {
+          start = IDX[start];
+          IDX[start] += 0;
+        }
       }
     }
   }
@@ -233,51 +170,43 @@ void SG_ADD( uint64_t *restrict ARRAY,
     {
 
       // Atomic F&A to order gangs
-      uint64_t gangID = __atomic_fetch_add(&gangCtr, (uint64_t)(0x1), __ATOMIC_RELAXED);
-      uint64_t i = 0;
-      uint64_t src = 0;
-      uint64_t dest = 0;
-      uint64_t val = 0;
-      uint64_t start = gangID * iters;
-
-      for( i=start; i<(start+iters); i++ ){
-        src  = __atomic_fetch_add( &IDX[i], (uint64_t)(0x00ull), __ATOMIC_RELAXED );
-        dest = __atomic_fetch_add( &IDX[i+1], (uint64_t)(0x00ull), __ATOMIC_RELAXED );
-        val = __atomic_fetch_add( &ARRAY[src], (uint64_t)(0x01ull), __ATOMIC_RELAXED );
-        __atomic_fetch_add( &ARRAY[dest], val, __ATOMIC_RELAXED );
+      uint64_t gangID;
+      #pragma acc atomic capture
+      {
+        gangID = gangCtr;
+        gangCtr++;
       }
-    }
-  }
-}
-
-void SG_CAS( uint64_t *restrict ARRAY,
-             uint64_t *restrict IDX,
-             uint64_t iters,
-             uint64_t pes ){
-
-  #pragma acc data deviceptr(ARRAY, IDX) copyin(iters, pes)
-  {
-    // target global variable for assigning gang IDs
-    uint64_t gangCtr = 0;
-    #pragma acc parallel num_gangs(pes)
-    {
-      // Atomic F&A to order gangs
-      uint64_t gangID = __atomic_fetch_add(&gangCtr, (uint64_t)(0x1), __ATOMIC_RELAXED);
       uint64_t i = 0;
       uint64_t src = 0;
       uint64_t dest = 0;
       uint64_t val = 0;
       uint64_t start = gangID * iters;
 
+      uint64_t ret;
       for( i=start; i<(start+iters); i++ ){
-        __atomic_compare_exchange_n( &IDX[i], &src, IDX[i],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-        __atomic_compare_exchange_n( &IDX[i+1], &dest, IDX[i+1],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-        __atomic_compare_exchange_n( &ARRAY[src], &val, ARRAY[src],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-        __atomic_compare_exchange_n( &ARRAY[dest], &ARRAY[dest], val,
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma acc atomic capture
+        {
+          src = IDX[i];
+          IDX[i] += 0;
+        }
+
+        #pragma acc atomic capture
+        {
+          dest = IDX[i+1];
+          IDX[i+1] += 0;
+        }
+
+        #pragma acc atomic capture
+        {
+          val = ARRAY[src];
+          ARRAY[src] += 1;
+        }
+
+        #pragma acc atomic capture
+        {
+          ret = ARRAY[dest];
+          ARRAY[dest] += val;
+        }
       }
     }
   }
@@ -292,27 +221,13 @@ void CENTRAL_ADD( uint64_t *restrict ARRAY,
   {
     #pragma acc parallel num_gangs(pes)
     {
-      uint64_t i;
+      uint64_t i, ret;
       for( i=0; i<iters; i++ ){
-        __atomic_fetch_add( &ARRAY[0], (uint64_t)(0x1), __ATOMIC_RELAXED );
-      }
-    }
-  }
-}
-
-void CENTRAL_CAS( uint64_t *restrict ARRAY,
-                  uint64_t *restrict IDX,
-                  uint64_t iters,
-                  uint64_t pes ){
-
-  #pragma acc data deviceptr(ARRAY, IDX) copyin(iters, pes)
-  {
-    #pragma acc parallel num_gangs(pes)
-    {
-      uint64_t i;
-      for( i=0; i<iters; i++ ){
-        __atomic_compare_exchange_n( &ARRAY[0], &ARRAY[0], ARRAY[0],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma acc atomic capture
+        {
+          ret = ARRAY[0];
+          ARRAY[0] += 1;
+        }
       }
     }
   }
@@ -330,46 +245,36 @@ void SCATTER_ADD( uint64_t *restrict ARRAY,
     #pragma acc parallel num_gangs(pes)
     {
       // Atomic F&A to order gangs
-      uint64_t gangID = __atomic_fetch_add(&gangCtr, (uint64_t)(0x1), __ATOMIC_RELAXED);
-      uint64_t i = 0;
-      uint64_t dest = 0;
-      uint64_t val = 0;
-      uint64_t start = gangID * iters;
-
-      for( i=start; i<(start+iters); i++ ){
-        dest = __atomic_fetch_add( &IDX[i+1], (uint64_t)(0x00ull), __ATOMIC_RELAXED );
-        val = __atomic_fetch_add( &ARRAY[i], (uint64_t)(0x01ull), __ATOMIC_RELAXED );
-        __atomic_fetch_add( &ARRAY[dest], val, __ATOMIC_RELAXED );
+      uint64_t gangID;
+      #pragma acc atomic capture
+      {
+        gangID = gangCtr;
+        gangCtr++;
       }
-    }
-  }
-}
-
-void SCATTER_CAS( uint64_t *restrict ARRAY,
-                  uint64_t *restrict IDX,
-                  uint64_t iters,
-                  uint64_t pes ){
-
-  #pragma acc data deviceptr(ARRAY, IDX) copyin(iters, pes)
-  {
-    // target global variable for assigning gang IDs
-    uint64_t gangCtr = 0;
-    #pragma acc parallel num_gangs(pes)
-    {
-      // Atomic F&A to order gangs
-      uint64_t gangID = __atomic_fetch_add(&gangCtr, (uint64_t)(0x1), __ATOMIC_RELAXED);
       uint64_t i = 0;
       uint64_t dest = 0;
       uint64_t val = 0;
       uint64_t start = gangID * iters;
 
+      uint64_t ret;
       for( i=start; i<(start+iters); i++ ){
-        __atomic_compare_exchange_n( &IDX[i+1], &dest, IDX[i+1],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-        __atomic_compare_exchange_n( &ARRAY[i], &val, ARRAY[i],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-        __atomic_compare_exchange_n( &ARRAY[dest], &ARRAY[dest], val,
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma acc atomic capture
+        {
+          dest = IDX[i+1];
+          IDX[i+1] += 0;
+        }
+
+        #pragma acc atomic capture
+        {
+          val = ARRAY[i];
+          ARRAY[i] += 1;
+        }
+
+        #pragma acc atomic capture
+        {
+          ret = ARRAY[dest];
+          ARRAY[dest] += val;
+        }
       }
     }
   }
@@ -387,46 +292,36 @@ void GATHER_ADD( uint64_t *restrict ARRAY,
     #pragma acc parallel num_gangs(pes)
     {
       // Atomic F&A to order gangs
-      uint64_t gangID = __atomic_fetch_add(&gangCtr, (uint64_t)(0x1), __ATOMIC_RELAXED);
-      uint64_t i = 0;
-      uint64_t dest = 0;
-      uint64_t val = 0;
-      uint64_t start = gangID * iters;
-
-      for( i=start; i<(start+iters); i++ ){
-        dest = __atomic_fetch_add( &IDX[i+1], (uint64_t)(0x00ull), __ATOMIC_RELAXED );
-        val = __atomic_fetch_add( &ARRAY[dest], (uint64_t)(0x01ull), __ATOMIC_RELAXED );
-        __atomic_fetch_add( &ARRAY[i], val, __ATOMIC_RELAXED );
+      uint64_t gangID;
+      #pragma acc atomic capture
+      {
+        gangID = gangCtr;
+        gangCtr++;
       }
-    }
-  }
-}
-
-void GATHER_CAS( uint64_t *restrict ARRAY,
-                 uint64_t *restrict IDX,
-                 uint64_t iters,
-                 uint64_t pes ){
-
-  #pragma acc data deviceptr(ARRAY, IDX) copyin(iters, pes)
-  {
-    // target global variable for assigning gang IDs
-    uint64_t gangCtr = 0;
-    #pragma acc parallel num_gangs(pes)
-    {
-      // Atomic F&A to order gangs
-      uint64_t gangID = __atomic_fetch_add(&gangCtr, (uint64_t)(0x1), __ATOMIC_RELAXED);
       uint64_t i = 0;
       uint64_t dest = 0;
       uint64_t val = 0;
       uint64_t start = gangID * iters;
 
+      uint64_t ret;
       for( i=start; i<(start+iters); i++ ){
-        __atomic_compare_exchange_n( &IDX[i+1], &dest, IDX[i+1],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-        __atomic_compare_exchange_n( &ARRAY[dest], &val, ARRAY[dest],
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
-        __atomic_compare_exchange_n( &ARRAY[i], &ARRAY[i], val,
-                                     0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
+        #pragma acc atomic capture
+        {
+          dest = IDX[i+1];
+          IDX[i+1] += 0;
+        }
+
+        #pragma acc atomic capture
+        {
+          val = ARRAY[dest];
+          ARRAY[dest] += 1;
+        }
+
+        #pragma acc atomic capture
+        {
+          ret = ARRAY[i];
+          ARRAY[i] += val;
+        }
       }
     }
   }

--- a/src/CircusTent/Impl/CT_PTHREADS/CT_PTHREADS.h
+++ b/src/CircusTent/Impl/CT_PTHREADS/CT_PTHREADS.h
@@ -165,13 +165,13 @@ void GATHER_CAS( uint64_t *ARRAY,
 
 class CT_PTHREADS : public CTBaseImpl{
 private:
-  uint64_t *Array;          ///< CT_OMP: Data array
-  uint64_t *Idx;            ///< CT_OMP: Index array
-  uint64_t memSize;         ///< CT_OMP: Memory size (in bytes)
-  uint64_t pes;             ///< CT_OMP: Number of processing elements
-  uint64_t iters;           ///< CT_OMP: Number of iterations per thread
-  uint64_t elems;           ///< CT_OMP: Number of u8 elements
-  uint64_t stride;          ///< CT_OMP: Stride in elements
+  uint64_t *Array;          ///< CT_PTHREADS: Data array
+  uint64_t *Idx;            ///< CT_PTHREADS: Index array
+  uint64_t memSize;         ///< CT_PTHREADS: Memory size (in bytes)
+  uint64_t pes;             ///< CT_PTHREADS: Number of processing elements
+  uint64_t iters;           ///< CT_PTHREADS: Number of iterations per thread
+  uint64_t elems;           ///< CT_PTHREADS: Number of u8 elements
+  uint64_t stride;          ///< CT_PTHREADS: Stride in elements
 
 public:
   /// CircusTent Pthreads constructor

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# src/ CMakeLists.txt
+# test/ CMakeLists.txt
 #
 # Copyright (C) 2017-2021 Tactical Computing Laboratories, LLC
 # All Rights Reserved


### PR DESCRIPTION
Adds another generic backend based on C++11 threads and atomic operations. Revises OpenACC and OMP_TARGET backend to use in-model AMOs rather than GNU intrinsic. Disables CAS-based atomics for OpenACC and OMP_TARGET due to lack of model support. 

Support for CAS in OMP can be added back using "#pragma omp atomic capture compare" once compiler support for OMP 5.1 is mode widely available.