### PR TITLE
Striden fix

### DIFF
--- a/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.cpp
+++ b/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.cpp
@@ -264,7 +264,7 @@ bool CT_CPP_STD::AllocateData(uint64_t m,
   elems = (memSize/8);
 
   // test to see whether we'll stride out of bounds
-  uint64_t end = (pes * iters * stride)-stride;
+  uint64_t end = (pes * iters * stride);
   if( end > elems ){
     std::cout << "CT_CPP_STD::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride

--- a/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD_IMPL.cpp
+++ b/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD_IMPL.cpp
@@ -123,8 +123,8 @@ void CT_CPP_STD::STRIDEN_ADD(uint64_t thread_id,
 
   // Perform atomic ops
   uint64_t i;
-  uint64_t start = thread_id * iters;
-  for(i = start; i < (start + iters); i += stride){
+  uint64_t start = thread_id * iters * stride;
+  for(i = start; i < (start + iters * stride); i += stride){
     Array[i].fetch_add((uint64_t)(0xF), std::memory_order_relaxed);
   }
 }
@@ -137,7 +137,7 @@ void CT_CPP_STD::STRIDEN_CAS(uint64_t thread_id,
   // Set up array of expected uint64_t values
   uint64_t i;
   uint64_t expected[iters];
-  uint64_t start = thread_id * iters;
+  uint64_t start = thread_id * iters * stride;
   for(i = 0; i < iters; i++){
     expected[i] = Array[start+(stride*i)];
   }

--- a/src/CircusTent/Impl/CT_OMP/CT_OMP.cpp
+++ b/src/CircusTent/Impl/CT_OMP/CT_OMP.cpp
@@ -226,7 +226,7 @@ bool CT_OMP::AllocateData( uint64_t m,
   elems = (memSize/8);
 
   // test to see whether we'll stride out of bounds
-  uint64_t end = (pes * iters * stride)-stride;
+  uint64_t end = (pes * iters * stride);
   if( end > elems ){
     std::cout << "CT_OMP::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride

--- a/src/CircusTent/Impl/CT_OMP/CT_OMP_IMPL.c
+++ b/src/CircusTent/Impl/CT_OMP/CT_OMP_IMPL.c
@@ -103,8 +103,8 @@ void STRIDEN_ADD( uint64_t *restrict ARRAY,
 
   #pragma omp parallel private(start,i)
   {
-    start = (uint64_t)(omp_get_thread_num()) * iters;
-    for( i=start; i<(start+iters); i+=stride ){
+    start = (uint64_t)(omp_get_thread_num()) * iters * stride;
+    for( i=start; i<(start+iters*stride); i+=stride ){
       __atomic_fetch_add( &ARRAY[i], (uint64_t)(0xF), __ATOMIC_RELAXED );
     }
   }
@@ -120,8 +120,8 @@ void STRIDEN_CAS( uint64_t *restrict ARRAY,
 
   #pragma omp parallel private(start,i)
   {
-    start = (uint64_t)(omp_get_thread_num()) * iters;
-    for( i=start; i<(start+iters); i+=stride ){
+    start = (uint64_t)(omp_get_thread_num()) * iters * stride;
+    for( i=start; i<(start+iters*stride); i+=stride ){
       __atomic_compare_exchange_n( &ARRAY[i], &ARRAY[i], ARRAY[i],
                                    0, __ATOMIC_RELAXED, __ATOMIC_RELAXED );
     }

--- a/src/CircusTent/Impl/CT_OMP_TARGET/CT_OMP_TARGET.cpp
+++ b/src/CircusTent/Impl/CT_OMP_TARGET/CT_OMP_TARGET.cpp
@@ -179,7 +179,7 @@ bool CT_OMP_TARGET::AllocateData( uint64_t m,
   elems = (memSize/8);
 
   // test to see whether we'll stride out of bounds
-  uint64_t end = (pes * iters * stride)-stride;
+  uint64_t end = (pes * iters * stride);
   if( end > elems ){
     std::cout << "CT_OMP_TARGET::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride

--- a/src/CircusTent/Impl/CT_OPENACC/CT_OPENACC.cpp
+++ b/src/CircusTent/Impl/CT_OPENACC/CT_OPENACC.cpp
@@ -180,7 +180,7 @@ bool CT_OPENACC::AllocateData( uint64_t m,
   elems = (memSize/8);
 
   // test to see whether we'll stride out of bounds
-  uint64_t end = (pes * iters * stride)-stride;
+  uint64_t end = (pes * iters * stride);
   if( end > elems ){
     std::cout << "CT_OPENACC::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride

--- a/src/CircusTent/Impl/CT_OPENACC/CT_OPENACC_IMPL.c
+++ b/src/CircusTent/Impl/CT_OPENACC/CT_OPENACC_IMPL.c
@@ -110,10 +110,10 @@ void STRIDEN_ADD( uint64_t *restrict ARRAY,
         gangID = gangCtr;
         gangCtr++;
       }
-      uint64_t start = gangID * iters;
+      uint64_t start = gangID * iters * stride;
 
       uint64_t ret;
-      for( i=start; i<(start+iters); i+=stride ){
+      for( i=start; i<(start+iters*stride); i+=stride ){
         #pragma acc atomic capture
         {
           ret = ARRAY[i];

--- a/src/CircusTent/Impl/CT_OPENCL/CT_OPENCL.cpp
+++ b/src/CircusTent/Impl/CT_OPENCL/CT_OPENCL.cpp
@@ -705,7 +705,7 @@ bool CT_OPENCL::AllocateData( cl_ulong m,
   elems = (memSize/8);
 
   // test to see whether we'll stride out of bounds
-  cl_ulong end = (pes * iters * stride) - stride;
+  cl_ulong end = (pes * iters * stride);
   if (end > elems){
     std::cout << "CT_OCL::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride

--- a/src/CircusTent/Impl/CT_OPENCL/CT_OPENCL_KERNELS.cl
+++ b/src/CircusTent/Impl/CT_OPENCL/CT_OPENCL_KERNELS.cl
@@ -60,8 +60,8 @@ __kernel void STRIDEN_ADD( __global ulong* ARRAY,
   ulong i      = 0;
   ulong start  = 0;
 
-  start = (ulong) (get_global_id(0) * iters);
-  for( i=start; i<(start+iters); i+=stride ){
+  start = (ulong) (get_global_id(0) * iters * stride);
+  for( i=start; i<(start+iters*stride); i+=stride ){
     atom_add(&ARRAY[i], (ulong)(0xF));
   }
 }
@@ -74,8 +74,8 @@ __kernel void STRIDEN_CAS( __global ulong* ARRAY,
   ulong i      = 0;
   ulong start  = 0;
 
-  start = (ulong) (get_global_id(0) * iters);
-  for( i=start; i<(start+iters); i+=stride ){
+  start = (ulong) (get_global_id(0) * iters * stride);
+  for( i=start; i<(start+iters*stride); i+=stride ){
     atom_cmpxchg(&ARRAY[i], ARRAY[i], ARRAY[i]);
   }
 }

--- a/src/CircusTent/Impl/CT_PTHREADS/CT_PTHREADS.cpp
+++ b/src/CircusTent/Impl/CT_PTHREADS/CT_PTHREADS.cpp
@@ -235,7 +235,7 @@ bool CT_PTHREADS::AllocateData( uint64_t m,
   elems = (memSize/8);
 
   // test to see whether we'll stride out of bounds
-  uint64_t end = (pes * iters * stride)-stride;
+  uint64_t end = (pes * iters * stride);
   if( end > elems ){
     std::cout << "CT_PTHREADS::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride

--- a/src/CircusTent/Impl/CT_PTHREADS/CT_PTHREADS_IMPL.c
+++ b/src/CircusTent/Impl/CT_PTHREADS/CT_PTHREADS_IMPL.c
@@ -312,8 +312,8 @@ void *thread_STRIDEN_ADD(void *thread_args){
 
   // Perform atomic ops
   uint64_t i;
-  uint64_t start = thread_id * iters;
-  for(i = start; i < (start + iters); i += stride){
+  uint64_t start = thread_id * iters * stride;
+  for(i = start; i < (start + iters * stride); i += stride){
     __atomic_fetch_add(&ARRAY[i], (uint64_t)(0xF), __ATOMIC_RELAXED);
   }
 
@@ -376,8 +376,8 @@ void *thread_STRIDEN_CAS(void *thread_args){
 
   // Perform atomic ops
   uint64_t i;
-  uint64_t start = thread_id * iters;
-  for(i = start; i < (start + iters); i += stride){
+  uint64_t start = thread_id * iters * stride;
+  for(i = start; i < (start + iters * stride); i += stride){
     __atomic_compare_exchange_n(&ARRAY[i], &ARRAY[i], ARRAY[i], 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
   }
 


### PR DESCRIPTION
Fix the number of iterations for the STRIDE-N kernel on CPP_STD, PTHREADS, OPENCL, OPENACC, OMP, AND OMP TARGET OFFLOADING backends.

Also, modify the out-of-bounds check for the STRIDE-N kernels on those backends.
I had to modify the start variable as well to avoid different threads accessing the same index.