### PR TITLE
Small fixes

### DIFF
--- a/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.cpp
+++ b/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.cpp
@@ -264,8 +264,8 @@ bool CT_CPP_STD::AllocateData(uint64_t m,
   elems = (memSize/8);
 
   // test to see whether we'll stride out of bounds
-  uint64_t end = (pes * iters * stride);
-  if( end > elems ){
+  uint64_t end = (pes * iters * stride) - stride;
+  if( end >= elems ){
     std::cout << "CT_CPP_STD::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride
               << std::endl;

--- a/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.cpp
+++ b/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.cpp
@@ -285,6 +285,13 @@ bool CT_CPP_STD::AllocateData(uint64_t m,
     return false;
   }
 
+  expected = new (std::nothrow) uint64_t[iters*pes];
+  if( expected == nullptr ) {
+    std::cout << "CT_CPP_STD::AllocateData : 'expected' could not be allocated" << std::endl;
+    delete[] expected;
+    return false;
+  }
+
   // initiate the random array
   srand(time(NULL));
   if( this->GetBenchType() == CT_PTRCHASE ){
@@ -312,6 +319,10 @@ bool CT_CPP_STD::FreeData(){
   if( Idx ){
     delete[] Idx;
   }
+  if( expected ){
+    delete[] expected;
+  }
+
   return true;
 }
 

--- a/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.h
+++ b/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD.h
@@ -38,6 +38,7 @@ private:
   uint64_t iters;                       ///< CT_CPP_STD: Number of iterations per thread
   uint64_t elems;                       ///< CT_CPP_STD: Number of u8 elements
   uint64_t stride;                      ///< CT_CPP_STD: Stride in elements
+  uint64_t* expected;                   ///< CT_CPP_STD: Expected Array for CAS kernels
 
 public:
   /// CircusTent C++ standard atomics constructor

--- a/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD_IMPL.cpp
+++ b/src/CircusTent/Impl/CT_CPP_STD/CT_CPP_STD_IMPL.cpp
@@ -40,10 +40,9 @@ void CT_CPP_STD::RAND_CAS(uint64_t thread_id,
 
   // Set up array of expected uint64_t values
   uint64_t i;
-  uint64_t expected[iters];
   uint64_t start = thread_id * iters;
   for(i = 0; i < iters; i++){
-    expected[i] = Array[Idx[start+i]];
+    expected[(thread_id*iters)+i] = Array[Idx[start+i]];
   }
 
   // Wait for all threads to be spawned
@@ -56,7 +55,7 @@ void CT_CPP_STD::RAND_CAS(uint64_t thread_id,
 
   // Perform atomic ops
   for(i = 0; i < iters; i++){
-    Array[Idx[start+i]].compare_exchange_strong(expected[i], Array[Idx[start+i]], std::memory_order_relaxed);
+    Array[Idx[start+i]].compare_exchange_strong(expected[(thread_id*iters)+i], Array[Idx[start+i]], std::memory_order_relaxed);
   }
 }
 
@@ -88,10 +87,9 @@ void CT_CPP_STD::STRIDE1_CAS(uint64_t thread_id,
 
   // Set up array of expected uint64_t values
   uint64_t i;
-  uint64_t expected[iters];
   uint64_t start = thread_id * iters;
   for(i = 0; i < iters; i++){
-    expected[i] = Array[start+i];
+    expected[(thread_id*iters)+i] = Array[start+i];
   }
 
   // Wait for all threads to be spawned
@@ -104,7 +102,7 @@ void CT_CPP_STD::STRIDE1_CAS(uint64_t thread_id,
 
   // Perform atomic ops
   for(i = 0; i < iters; i++){
-    Array[start+i].compare_exchange_strong(expected[i], Array[start+i], std::memory_order_relaxed);
+    Array[start+i].compare_exchange_strong(expected[(thread_id*iters)+i], Array[start+i], std::memory_order_relaxed);
   }
 }
 
@@ -136,10 +134,9 @@ void CT_CPP_STD::STRIDEN_CAS(uint64_t thread_id,
 
   // Set up array of expected uint64_t values
   uint64_t i;
-  uint64_t expected[iters];
   uint64_t start = thread_id * iters * stride;
   for(i = 0; i < iters; i++){
-    expected[i] = Array[start+(stride*i)];
+    expected[(thread_id*iters)+i] = Array[start+(stride*i)];
   }
 
   // Wait for all threads to be spawned
@@ -152,7 +149,7 @@ void CT_CPP_STD::STRIDEN_CAS(uint64_t thread_id,
 
   // Perform atomic ops
   for(i = 0; i < iters; i++){
-    Array[start+(stride*i)].compare_exchange_strong(expected[i], Array[start+(stride*i)], std::memory_order_relaxed);
+    Array[start+(stride*i)].compare_exchange_strong(expected[(thread_id*iters)+i], Array[start+(stride*i)], std::memory_order_relaxed);
   }
 }
 
@@ -229,10 +226,9 @@ void CT_CPP_STD::SG_CAS(uint64_t thread_id,
 
   // Set up array of expected uint64_t values
   uint64_t i;
-  uint64_t expected[iters];
   uint64_t start = thread_id * iters;
   for(i = 0; i < iters; i++){
-    expected[i] = Array[Idx[start+i+1]];
+    expected[(thread_id*iters)+i] = Array[Idx[start+i+1]];
   }
 
   // Wait for all threads to be spawned
@@ -253,8 +249,8 @@ void CT_CPP_STD::SG_CAS(uint64_t thread_id,
     Idx[start+i+1].compare_exchange_strong(dest, Idx[start+i+1], std::memory_order_relaxed);
     Array[src].compare_exchange_strong(val, Array[src], std::memory_order_relaxed);
     // AMO #4 issue - expected may not equal Array[dest] due to previous ops
-    // Result: expected[i] <- Array[dest] rather than Array[dest] <- val
-    Array[dest].compare_exchange_strong(expected[i], val, std::memory_order_relaxed);
+    // Result: expected[(thread_id*iters)+i] <- Array[dest] rather than Array[dest] <- val
+    Array[dest].compare_exchange_strong(expected[(thread_id*iters)+i], val, std::memory_order_relaxed);
   }
 }
 
@@ -331,10 +327,9 @@ void CT_CPP_STD::SCATTER_CAS(uint64_t thread_id,
 
   // Set up array of expected uint64_t values
   uint64_t i;
-  uint64_t expected[iters];
   uint64_t start = thread_id * iters;
   for(i = 0; i < iters; i++){
-    expected[i] = Array[Idx[start+i+1]];
+    expected[(thread_id*iters)+i] = Array[Idx[start+i+1]];
   }
 
   // Wait for all threads to be spawned
@@ -353,8 +348,8 @@ void CT_CPP_STD::SCATTER_CAS(uint64_t thread_id,
     Idx[start+i+1].compare_exchange_strong(dest, Idx[start+i+1], std::memory_order_relaxed);
     Array[start+i].compare_exchange_strong(val, Array[start+i], std::memory_order_relaxed);
     // AMO #3 issue - expected may not equal Array[dest] due to previous ops
-    // Result: expected[i] <- Array[dest] rather than Array[dest] <- val
-    Array[dest].compare_exchange_strong(expected[i], val, std::memory_order_relaxed);
+    // Result: expected[(thread_id*iters)+i] <- Array[dest] rather than Array[dest] <- val
+    Array[dest].compare_exchange_strong(expected[(thread_id*iters)+i], val, std::memory_order_relaxed);
   }
 }
 
@@ -390,10 +385,9 @@ void CT_CPP_STD::GATHER_CAS(uint64_t thread_id,
 
   // Set up array of expected uint64_t values
   uint64_t i;
-  uint64_t expected[iters];
   uint64_t start = thread_id * iters;
   for(i = 0; i < iters; i++){
-    expected[i] = Array[start+i];
+    expected[(thread_id*iters)+i] = Array[start+i];
   }
 
   // Wait for all threads to be spawned
@@ -411,7 +405,7 @@ void CT_CPP_STD::GATHER_CAS(uint64_t thread_id,
   for(i = 0; i < iters; i++){
     Idx[start+i+1].compare_exchange_strong(dest, Idx[start+i+1], std::memory_order_relaxed);
     Array[dest].compare_exchange_strong(val, Array[dest], std::memory_order_relaxed);
-    Array[start+i].compare_exchange_strong(expected[i], val, std::memory_order_relaxed);
+    Array[start+i].compare_exchange_strong(expected[(thread_id*iters)+i], val, std::memory_order_relaxed);
   }
 }
 

--- a/src/CircusTent/Impl/CT_MPI/CT_MPI.cpp
+++ b/src/CircusTent/Impl/CT_MPI/CT_MPI.cpp
@@ -271,7 +271,7 @@ bool CT_MPI::AllocateData( uint64_t m,
 
   // test to see whether we'll stride out of bounds
   uint64_t end = (iters * stride)-stride;
-  if( end > elems ){
+  if( end >= elems ){
     std::cout << "CT_MPI::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride
               << std::endl;

--- a/src/CircusTent/Impl/CT_OMP/CT_OMP.cpp
+++ b/src/CircusTent/Impl/CT_OMP/CT_OMP.cpp
@@ -226,8 +226,8 @@ bool CT_OMP::AllocateData( uint64_t m,
   elems = (memSize/8);
 
   // test to see whether we'll stride out of bounds
-  uint64_t end = (pes * iters * stride);
-  if( end > elems ){
+  uint64_t end = (pes * iters * stride) - stride;
+  if( end >= elems ){
     std::cout << "CT_OMP::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride
               << std::endl;

--- a/src/CircusTent/Impl/CT_OMP_TARGET/CT_OMP_TARGET.cpp
+++ b/src/CircusTent/Impl/CT_OMP_TARGET/CT_OMP_TARGET.cpp
@@ -179,8 +179,8 @@ bool CT_OMP_TARGET::AllocateData( uint64_t m,
   elems = (memSize/8);
 
   // test to see whether we'll stride out of bounds
-  uint64_t end = (pes * iters * stride);
-  if( end > elems ){
+  uint64_t end = (pes * iters * stride) - stride;
+  if( end >= elems ){
     std::cout << "CT_OMP_TARGET::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride
               << std::endl;

--- a/src/CircusTent/Impl/CT_OMP_TARGET/CT_OMP_TARGET_IMPL.c
+++ b/src/CircusTent/Impl/CT_OMP_TARGET/CT_OMP_TARGET_IMPL.c
@@ -98,11 +98,12 @@ void STRIDEN_ADD( uint64_t *restrict ARRAY,
       // Divide iters across number of threads per team & set start
       uint64_t num_threads = (uint64_t) omp_get_num_threads();
       uint64_t num_teams = (uint64_t) omp_get_num_teams();
-      uint64_t iters_per_thread = (uint64_t) iters / num_threads;
+      uint64_t total_threads = num_teams * num_threads;
+      uint64_t iters_per_thread = (uint64_t) iters / total_threads;
       uint64_t start = (uint64_t) (omp_get_team_num() * num_threads + omp_get_thread_num()) * iters_per_thread * stride;
 
       if(omp_get_thread_num() == num_threads - 1 && omp_get_team_num() == num_teams - 1)
-        iters_per_thread += (uint64_t) (iters % num_threads);
+        iters_per_thread += (uint64_t) (iters % total_threads);
 
       uint64_t ret;
       for( i=start; i<(start+iters_per_thread*stride); i+=stride ){

--- a/src/CircusTent/Impl/CT_OPENACC/CT_OPENACC.cpp
+++ b/src/CircusTent/Impl/CT_OPENACC/CT_OPENACC.cpp
@@ -180,8 +180,8 @@ bool CT_OPENACC::AllocateData( uint64_t m,
   elems = (memSize/8);
 
   // test to see whether we'll stride out of bounds
-  uint64_t end = (pes * iters * stride);
-  if( end > elems ){
+  uint64_t end = (pes * iters * stride) - stride;
+  if( end >= elems ){
     std::cout << "CT_OPENACC::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride
               << std::endl;

--- a/src/CircusTent/Impl/CT_OPENCL/CT_OPENCL.cpp
+++ b/src/CircusTent/Impl/CT_OPENCL/CT_OPENCL.cpp
@@ -705,8 +705,8 @@ bool CT_OPENCL::AllocateData( cl_ulong m,
   elems = (memSize/8);
 
   // test to see whether we'll stride out of bounds
-  cl_ulong end = (pes * iters * stride);
-  if (end > elems){
+  cl_ulong end = (pes * iters * stride) - stride;
+  if (end >= elems){
     std::cout << "CT_OCL::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride
               << std::endl;

--- a/src/CircusTent/Impl/CT_OPENSHMEM/CT_SHMEM.cpp
+++ b/src/CircusTent/Impl/CT_OPENSHMEM/CT_SHMEM.cpp
@@ -264,7 +264,7 @@ bool CT_SHMEM::AllocateData( uint64_t m,
 
   // test to see whether we'll stride out of bounds
   uint64_t end = (iters * stride)-stride;
-  if( end > elems ){
+  if( end >= elems ){
     std::cout << "CT_SHMEM::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride
               << std::endl;

--- a/src/CircusTent/Impl/CT_PTHREADS/CT_PTHREADS.cpp
+++ b/src/CircusTent/Impl/CT_PTHREADS/CT_PTHREADS.cpp
@@ -235,8 +235,8 @@ bool CT_PTHREADS::AllocateData( uint64_t m,
   elems = (memSize/8);
 
   // test to see whether we'll stride out of bounds
-  uint64_t end = (pes * iters * stride);
-  if( end > elems ){
+  uint64_t end = (pes * iters * stride) - stride;
+  if( end >= elems ){
     std::cout << "CT_PTHREADS::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride
               << std::endl;

--- a/src/CircusTent/Impl/CT_XBGAS/CT_XBGAS.cpp
+++ b/src/CircusTent/Impl/CT_XBGAS/CT_XBGAS.cpp
@@ -264,7 +264,7 @@ bool CT_XBGAS::AllocateData( uint64_t m,
 
   // test to see whether we'll stride out of bounds
   uint64_t end = (iters * stride)-stride;
-  if( end > elems ){
+  if( end >= elems ){
     std::cout << "CT_XBGAS::AllocateData : 'Array' is not large enough for pes="
               << pes << "; iters=" << iters << ";stride =" << stride
               << std::endl;


### PR DESCRIPTION
This PR:
- solves #20 by allocating a single array to all threads dynamically instead of each array having its own expected[] array allocated on the stack.
- fix out-of-bounds check to a tighter one (@BrodyWilliams was the one who found that out)
- fix the number of threads from OMP_TARGET_OFFLOADING's STRIDE-N kernel (Also @BrodyWilliams)